### PR TITLE
[chore] 리뷰어 자동 할당 도입

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# .github/CODEOWNERS
+
+# 1. 기본 담당자 (Fallback)
+* @Namsoo315
+
+# 2. 구체적인 도메인 담당자
+# user 도메인 담당자
+/monew/src/main/java/com/spring/monew/user/   @kimyumin03
+/monew/src/main/java/com/spring/monew/auth/   @kimyumin03
+# comment 도메인 담당자
+/monew/src/main/java/com/spring/monew/comment/    @kimyumin03
+/monew/src/main/java/com/spring/monew/commentlike/ @kimyumin03
+
+# article 도메인 담당자
+/monew/src/main/java/com/spring/monew/article/    @haram-jo
+/monew/src/main/java/com/spring/monew/articleview/ @haram-jo
+
+# activity 도메인 담당자
+/monew/src/main/java/com/spring/monew/activity/ @yuhandemian
+# notification 도메인 담당자
+/monew/src/main/java/com/spring/monew/notification/ @yuhandemian
+# interest 도메인 담당자
+/monew/src/main/java/com/spring/monew/interest/ @yuhandemian
+/monew/src/main/java/com/spring/monew/subscribe/ @yuhandemian


### PR DESCRIPTION
## Issues
- closed #8

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
CODEOWNERS 파일을 이용한 리뷰어 자동 할당 도입

* **파일 추가:** `.github/CODEOWNERS`
    * 각 도메인(디렉토리)별 리뷰 담당자를 매핑했습니다.
    
## 📷 Screenshot

## 📚 Reference
* 이제 PR 생성 시 이 `CODEOWNERS` 파일에 정의된 담당자가 자동으로 리뷰어(Reviewers)로 지정됩니다.
* 향후 도메인별 담당자 변경이 필요할 경우, 워크플로우가 아닌 `.github/CODEOWNERS` 파일만 수정해 주시면 됩니다.