### PR TITLE
[fix] 댓글 논리 삭제 처리 및 refactor

### DIFF
--- a/monew/src/main/java/com/spring/monew/article/batch/scheduler/CommentCleanupScheduler.java
+++ b/monew/src/main/java/com/spring/monew/article/batch/scheduler/CommentCleanupScheduler.java
@@ -1,0 +1,31 @@
+package com.spring.monew.article.batch.scheduler;
+
+import com.spring.monew.comment.repository.CommentRepository;
+import jakarta.transaction.Transactional;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CommentCleanupScheduler {
+
+  private final CommentRepository commentRepository;
+
+  @Scheduled(cron = "0 0 0 * * *") // 매일 00시에 스케쥴링 작동
+  @Transactional
+  public void deleteSoftDeletedComments() {
+
+    // 1시간전 처리
+    Instant threshold = Instant.now().minus(1, ChronoUnit.HOURS);
+
+    int deletedCount = commentRepository.deleteSoftDeletedBefore(threshold);
+
+    log.info("[Batch] Hard Deleted Comments = {}", deletedCount);
+  }
+}
+

--- a/monew/src/main/java/com/spring/monew/comment/domain/Comment.java
+++ b/monew/src/main/java/com/spring/monew/comment/domain/Comment.java
@@ -18,65 +18,70 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "comments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @SQLDelete(sql = "UPDATE comments SET is_deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
-@SQLRestriction("is_deleted = false") // 조회 시 기본적으로 삭제되지 않은 것만 조회
+@FilterDef(name = "deletedFilter", parameters = @ParamDef(name = "isDeleted", type = Boolean.class))
+@Filter(name = "deletedFilter", condition = "is_deleted = :isDeleted")
 public class Comment {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)   //PK 자동 삽입
-    private UUID id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)   //PK 자동 삽입
+  private UUID id;
 
-    @ManyToOne
-    @JoinColumn(name = "article_id", nullable = false)
-    private Article article;
+  @ManyToOne
+  @JoinColumn(name = "article_id", nullable = false)
+  private Article article;
 
-     @ManyToOne(fetch = FetchType.LAZY)
-     @JoinColumn(name = "user_id", nullable = false)
-     private User user;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
-    @Column(nullable = false)
-    private String content;
+  @Column(nullable = false)
+  private String content;
 
-    @Column(name = "created_at", nullable = false)
-    @CreationTimestamp
-    private Instant createdAt;
+  @Column(name = "created_at", nullable = false)
+  @CreationTimestamp
+  private Instant createdAt;
 
-    @Column(name = "is_deleted", nullable = false)
-    @ColumnDefault("false")
-    private boolean isDeleted;
+  @Column(name = "is_deleted", nullable = false)
+  @ColumnDefault("false")
+  private boolean isDeleted;
 
-    @Column(name = "deleted_at")
-    private Instant deletedAt;
+  @Column(name = "deleted_at")
+  private Instant deletedAt;
 
-    @Column(name = "like_count", nullable = false)
-    @ColumnDefault("0")
-    private long likeCount;
+  @Column(name = "like_count", nullable = false)
+  @ColumnDefault("0")
+  private long likeCount;
 
-    public Comment(Article article, User user,String content) {
-        this.article = article;
-        this.user = user;
-        this.content = content;
-        this.createdAt = Instant.now();
+  public Comment(Article article, User user, String content) {
+    this.article = article;
+    this.user = user;
+    this.content = content;
+    this.createdAt = Instant.now();
+  }
+
+  public void update(String content) {
+      if (content != null && !content.isEmpty()) {
+          this.content = content;
+      }
+  }
+
+  public void incrementLikeCount() {
+    this.likeCount++;
+  }
+
+  public void decrementLikeCount() {
+    if (this.likeCount > 0) {
+      this.likeCount--;
     }
-
-    public void update(String content) {
-        if (content != null &&  !content.isEmpty()) this.content = content;
-    }
-
-    public void incrementLikeCount() {
-        this.likeCount++;
-    }
-
-    public void decrementLikeCount() {
-        if (this.likeCount > 0) {
-            this.likeCount--;
-        }
-    }
+  }
 }

--- a/monew/src/main/java/com/spring/monew/comment/repository/CommentRepository.java
+++ b/monew/src/main/java/com/spring/monew/comment/repository/CommentRepository.java
@@ -2,6 +2,8 @@ package com.spring.monew.comment.repository;
 
 import com.spring.monew.comment.domain.Comment;
 import com.spring.monew.user.domain.User;
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,5 +16,12 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
   @Query("DELETE FROM Comment c where c.id = :commentId")
   void deletePhysicalById(@Param("commentId") UUID commentId);
 
-  UUID user(User user);
+  @Modifying
+  @Query(value = """
+    DELETE FROM comments
+    WHERE is_deleted = true
+      AND deleted_at IS NOT NULL
+      AND deleted_at < :threshold
+    """, nativeQuery = true)
+  int deleteSoftDeletedBefore(@Param("threshold") Instant threshold);
 }

--- a/monew/src/main/java/com/spring/monew/comment/repository/impl/CommentRepositoryCustomImpl.java
+++ b/monew/src/main/java/com/spring/monew/comment/repository/impl/CommentRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.spring.monew.comment.repository.impl;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -35,7 +36,7 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
     builder.and(comment.isDeleted.eq(false));
 
     // 커서 조건
-    extracted(direction, cursor, builder);
+    applyCursorCondition(orderBy, direction, cursor, builder);
 
     BooleanExpression likedByUser = JPAExpressions
         .selectOne()
@@ -86,35 +87,50 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
         hasNext
     );
   }
+    private void applyCursorCondition(String orderBy, String direction, String cursor, BooleanBuilder builder) {
+      if (cursor == null) return;
 
-  private void extracted(String direction, String cursor, BooleanBuilder builder) {
-    Instant cursorCreatedAt = null;
+      UUID cursorId;
+      try {
+        cursorId = UUID.fromString(cursor);
+      } catch (IllegalArgumentException e) {
+        return;
+      }
 
-    if (cursor != null) {
-      UUID cursorId = UUID.fromString(cursor);
-
-      cursorCreatedAt = queryFactory
-          .select(comment.createdAt)
+      // ✅ primary + createdAt 한 번에 조회
+      Tuple row = queryFactory
+          .select(comment.likeCount, comment.createdAt)
           .from(comment)
           .where(comment.id.eq(cursorId))
           .fetchOne();
 
-      if (cursorCreatedAt != null) {
-        boolean isAsc = "ASC".equalsIgnoreCase(direction);
+      if (row == null) return;
 
-        builder.and(
-            isAsc ?
-                comment.createdAt.gt(cursorCreatedAt)
-                    .or(comment.createdAt.eq(cursorCreatedAt)
-                        .and(comment.id.gt(cursorId)))
-                :
-                    comment.createdAt.lt(cursorCreatedAt)
-                        .or(comment.createdAt.eq(cursorCreatedAt)
-                            .and(comment.id.lt(cursorId)))
+      Long cursorLikes = row.get(comment.likeCount);
+      Instant cursorCreatedAt = row.get(comment.createdAt);
+      boolean isAsc = "ASC".equalsIgnoreCase(direction);
+
+      // ✅ tie-breaker: createdAt → id
+      BooleanExpression byCreatedAtThenId = isAsc
+          ? comment.createdAt.gt(cursorCreatedAt)
+          .or(comment.createdAt.eq(cursorCreatedAt)
+              .and(comment.id.gt(cursorId)))
+          : comment.createdAt.lt(cursorCreatedAt)
+              .or(comment.createdAt.eq(cursorCreatedAt)
+                  .and(comment.id.lt(cursorId)));
+
+      // ✅ primary 기준 동적 처리
+      switch (orderBy) {
+        case "likeCount" -> builder.and(
+            isAsc
+                ? comment.likeCount.gt(cursorLikes)
+                .or(comment.likeCount.eq(cursorLikes).and(byCreatedAtThenId))
+                : comment.likeCount.lt(cursorLikes)
+                    .or(comment.likeCount.eq(cursorLikes).and(byCreatedAtThenId))
         );
+        case "createdAt", default -> builder.and(byCreatedAtThenId);
       }
     }
-  }
   // 유틸 메서드
 
   private OrderSpecifier<?> getOrderSpecifier(String orderBy, String direction) {

--- a/monew/src/main/java/com/spring/monew/comment/repository/impl/CommentRepositoryCustomImpl.java
+++ b/monew/src/main/java/com/spring/monew/comment/repository/impl/CommentRepositoryCustomImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.spring.monew.comment.controller.dto.response.CommentDto;
 import com.spring.monew.comment.controller.dto.response.CursorPageResponseCommentDto;
@@ -33,32 +34,38 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
     builder.and(comment.article.id.eq(articleId));
     builder.and(comment.isDeleted.eq(false));
 
-    BooleanExpression cursorCondition = buildCursorCondition(direction, cursor, after);
-    if (cursorCondition != null) {
-      builder.and(cursorCondition);
-    }
+    // 커서 조건
+    extracted(direction, cursor, builder);
+
+    BooleanExpression likedByUser = JPAExpressions
+        .selectOne()
+        .from(commentLike)
+        .where(commentLike.comment.id.eq(comment.id)
+            .and(commentLike.user.id.eq(userId)))
+        .exists();
+
     // 정렬 기준
     OrderSpecifier<?> primaryOrder = getOrderSpecifier(orderBy, direction);
     OrderSpecifier<?> secondaryOrder = getCreatedAtOrderSpecifier(direction);
+    OrderSpecifier<?> stabilityOrder = new OrderSpecifier<>(
+        "ASC".equalsIgnoreCase(direction) ? Order.ASC : Order.DESC,
+        comment.id
+    );
 
     List<CommentDto> results = queryFactory
         .select(new QCommentDto(
-                comment.id,
+            comment.id,
             comment.article.id,
             comment.user.id,
             comment.user.nickname,
             comment.content,
             comment.likeCount,
-            commentLike.id.isNotNull(),
+            likedByUser,
             comment.createdAt
-            )
-        )
+        ))
         .from(comment)
-        .leftJoin(commentLike)
-        .on(commentLike.comment.id.eq(comment.id)
-            .and(commentLike.user.id.eq(userId)))
         .where(builder)
-        .orderBy(primaryOrder, secondaryOrder)
+        .orderBy(primaryOrder, secondaryOrder, stabilityOrder)
         .limit(limit + 1)
         .fetch();
 
@@ -79,20 +86,36 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
         hasNext
     );
   }
-  // 유틸 메서드
 
-  private BooleanExpression buildCursorCondition(String direction, String cursor, Instant after) {
-    if (cursor == null || after == null) return null;
+  private void extracted(String direction, String cursor, BooleanBuilder builder) {
+    Instant cursorCreatedAt = null;
 
-    UUID cursorId = UUID.fromString(cursor);
-    boolean isAsc = "ASC".equalsIgnoreCase(direction);
+    if (cursor != null) {
+      UUID cursorId = UUID.fromString(cursor);
 
-    return isAsc
-        ? comment.createdAt.after(after)
-        .or(comment.createdAt.eq(after).and(comment.id.gt(cursorId)))
-        : comment.createdAt.before(after)
-            .or(comment.createdAt.eq(after).and(comment.id.lt(cursorId)));
+      cursorCreatedAt = queryFactory
+          .select(comment.createdAt)
+          .from(comment)
+          .where(comment.id.eq(cursorId))
+          .fetchOne();
+
+      if (cursorCreatedAt != null) {
+        boolean isAsc = "ASC".equalsIgnoreCase(direction);
+
+        builder.and(
+            isAsc ?
+                comment.createdAt.gt(cursorCreatedAt)
+                    .or(comment.createdAt.eq(cursorCreatedAt)
+                        .and(comment.id.gt(cursorId)))
+                :
+                    comment.createdAt.lt(cursorCreatedAt)
+                        .or(comment.createdAt.eq(cursorCreatedAt)
+                            .and(comment.id.lt(cursorId)))
+        );
+      }
+    }
   }
+  // 유틸 메서드
 
   private OrderSpecifier<?> getOrderSpecifier(String orderBy, String direction) {
     Order order = "DESC".equalsIgnoreCase(direction) ? Order.DESC : Order.ASC;

--- a/monew/src/main/java/com/spring/monew/common/config/HibernateFilterAspect.java
+++ b/monew/src/main/java/com/spring/monew/common/config/HibernateFilterAspect.java
@@ -14,10 +14,10 @@ import org.springframework.stereotype.Component;
 public class HibernateFilterAspect {
 
   @PersistenceContext
-  private final EntityManager em;
+  private EntityManager em;
 
   // isDeleted가 false인 데이터만 보이게 해줌.
-  @Before("execution(* com.spring.monew..reposiotry..*(..))")
+  @Before("execution(* com.spring.monew..repository..*(..))")
   public void enableFilter() {
     em.unwrap(Session.class)
         .enableFilter("deletedFilter")

--- a/monew/src/main/java/com/spring/monew/common/config/HibernateFilterAspect.java
+++ b/monew/src/main/java/com/spring/monew/common/config/HibernateFilterAspect.java
@@ -1,0 +1,26 @@
+package com.spring.monew.common.config;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.hibernate.Session;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class HibernateFilterAspect {
+
+  @PersistenceContext
+  private final EntityManager em;
+
+  // isDeleted가 false인 데이터만 보이게 해줌.
+  @Before("execution(* com.spring.monew..reposiotry..*(..))")
+  public void enableFilter() {
+    em.unwrap(Session.class)
+        .enableFilter("deletedFilter")
+        .setParameter("isDeleted", false);
+  }
+}

--- a/monew/src/main/java/com/spring/monew/interest/repository/impl/InterestRepositoryCustomImpl.java
+++ b/monew/src/main/java/com/spring/monew/interest/repository/impl/InterestRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.spring.monew.interest.repository.impl;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -42,7 +43,7 @@ public class InterestRepositoryCustomImpl implements InterestRepositoryCustom {
     }
 
     // 커서 조건
-    extracted(direction, cursor, builder);
+    applyCursorCondition(orderBy, direction, cursor, builder);
 
     BooleanExpression subscribedExpression = JPAExpressions
         .selectOne()
@@ -75,7 +76,9 @@ public class InterestRepositoryCustomImpl implements InterestRepositoryCustom {
         .fetch();
 
     boolean hasNext = results.size() > limit;
-    if (hasNext) results.remove(limit);
+    if (hasNext) {
+      results.remove(limit);
+    }
 
     String nextCursor = hasNext ? results.get(results.size() - 1).id().toString() : null;
     Instant nextAfter = hasNext ? results.get(results.size() - 1).createdAt() : null;
@@ -92,30 +95,64 @@ public class InterestRepositoryCustomImpl implements InterestRepositoryCustom {
 
   //유틸 메서드
 
-  private void extracted(String direction, String cursor, BooleanBuilder builder) {
-    Instant cursorCreatedAt = null;
-    if (cursor != null) {
-      UUID cursorId = UUID.fromString(cursor);
+  private void applyCursorCondition(String orderBy, String direction, String cursor,
+      BooleanBuilder builder) {
+    if (cursor == null) {
+      return;
+    }
 
-      cursorCreatedAt = queryFactory
-          .select(interest.createdAt)
-          .from(interest)
-          .where(interest.id.eq(cursorId))
-          .fetchOne();
+    UUID cursorId;
+    try {
+      cursorId = UUID.fromString(cursor);
+    } catch (IllegalArgumentException e) {
+      return;
+    }
 
-      if (cursorCreatedAt != null) {
-        boolean isAsc = "ASC".equalsIgnoreCase(direction);
+    // ✅ primary + createdAt 한번에 조회
+    Tuple row = queryFactory
+        .select(interest.name, interest.subscriptionsCount, interest.createdAt)
+        .from(interest)
+        .where(interest.id.eq(cursorId))
+        .fetchOne();
 
-        builder.and(
-            isAsc
-                ? interest.createdAt.gt(cursorCreatedAt)
-                .or(interest.createdAt.eq(cursorCreatedAt)
-                    .and(interest.id.gt(cursorId)))
-                : interest.createdAt.lt(cursorCreatedAt)
-                    .or(interest.createdAt.eq(cursorCreatedAt)
-                        .and(interest.id.lt(cursorId)))
-        );
-      }
+    if (row == null) {
+      return;
+    }
+
+    String cursorName = row.get(interest.name);
+    Long cursorSubs = row.get(interest.subscriptionsCount);
+    Instant cursorCreatedAt = row.get(interest.createdAt);
+
+    boolean isAsc = "ASC".equalsIgnoreCase(direction);
+
+    // ✅ tie-breaker: createdAt → id
+    BooleanExpression byCreatedAtThenId = isAsc
+        ? interest.createdAt.gt(cursorCreatedAt)
+        .or(interest.createdAt.eq(cursorCreatedAt)
+            .and(interest.id.gt(cursorId)))
+        : interest.createdAt.lt(cursorCreatedAt)
+            .or(interest.createdAt.eq(cursorCreatedAt)
+                .and(interest.id.lt(cursorId)));
+
+    // ✅ primary 정렬 기준에 맞춘 cursor 처리
+    switch (orderBy) {
+      case "subscriberCount" -> builder.and(
+          isAsc
+              ? interest.subscriptionsCount.gt(cursorSubs)
+              .or(interest.subscriptionsCount.eq(cursorSubs).and(byCreatedAtThenId))
+              : interest.subscriptionsCount.lt(cursorSubs)
+                  .or(interest.subscriptionsCount.eq(cursorSubs).and(byCreatedAtThenId))
+      );
+
+      case "name" -> builder.and(
+          isAsc
+              ? interest.name.gt(cursorName)
+              .or(interest.name.eq(cursorName).and(byCreatedAtThenId))
+              : interest.name.lt(cursorName)
+                  .or(interest.name.eq(cursorName).and(byCreatedAtThenId))
+      );
+
+      default -> builder.and(byCreatedAtThenId);
     }
   }
 
@@ -142,7 +179,8 @@ public class InterestRepositoryCustomImpl implements InterestRepositoryCustom {
   private OrderSpecifier<?> getOrderSpecifier(String orderBy, String direction) {
     Order order = "DESC".equalsIgnoreCase(direction) ? Order.DESC : Order.ASC;
     return switch (orderBy) {
-      case "subscriberCount" -> new OrderSpecifier<>(order, InterestRepositoryCustomImpl.interest.subscriptionsCount);
+      case "subscriberCount" ->
+          new OrderSpecifier<>(order, InterestRepositoryCustomImpl.interest.subscriptionsCount);
       case "name" -> new OrderSpecifier<>(order, InterestRepositoryCustomImpl.interest.name);
       default -> new OrderSpecifier<>(order, InterestRepositoryCustomImpl.interest.name);
     };

--- a/monew/src/main/java/com/spring/monew/interest/repository/impl/InterestRepositoryCustomImpl.java
+++ b/monew/src/main/java/com/spring/monew/interest/repository/impl/InterestRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.spring.monew.interest.controller.dto.response.CursorPageResponseInterestDto;
 import com.spring.monew.interest.controller.dto.response.InterestDto;
@@ -27,26 +28,36 @@ public class InterestRepositoryCustomImpl implements InterestRepositoryCustom {
   private static final QSubscription subscription = QSubscription.subscription;
 
   @Override
-  public CursorPageResponseInterestDto findCursorPagedInterests(String keyword, String orderBy,
-      String direction, String cursor, Instant after, int limit, UUID userId) {
+  public CursorPageResponseInterestDto findCursorPagedInterests(
+      String keyword, String orderBy, String direction,
+      String cursor, Instant after, int limit, UUID userId) {
 
     BooleanBuilder builder = new BooleanBuilder();
 
-    // 검색 조건 (keyword, interestName)
     if (keyword != null && !keyword.isEmpty()) {
       builder.and(
           interest.name.containsIgnoreCase(keyword)
-              .or(interest.keywordsString.containsIgnoreCase(keyword))  // JSON 문자열에 LIKE
+              .or(interest.keywordsString.containsIgnoreCase(keyword))
       );
     }
 
-    BooleanExpression cursorCondition = buildCursorCondition(direction, cursor, after);
-    if (cursorCondition != null) {
-      builder.and(cursorCondition);
-    }
-    // 정렬 기준
+    // 커서 조건
+    extracted(direction, cursor, builder);
+
+    BooleanExpression subscribedExpression = JPAExpressions
+        .selectOne()
+        .from(subscription)
+        .where(subscription.interest.id.eq(interest.id)
+            .and(subscription.user.id.eq(userId)))
+        .exists();
+
+    // 정렬 옵션
     OrderSpecifier<?> primaryOrder = getOrderSpecifier(orderBy, direction);
     OrderSpecifier<?> secondaryOrder = getCreatedAtOrderSpecifier(direction);
+    OrderSpecifier<?> stabilityOrder = new OrderSpecifier<>(
+        "ASC".equalsIgnoreCase(direction) ? Order.ASC : Order.DESC,
+        interest.id
+    );
 
     List<InterestDto> results = queryFactory
         .select(new QInterestDto(
@@ -54,23 +65,18 @@ public class InterestRepositoryCustomImpl implements InterestRepositoryCustom {
             interest.name,
             interest.keywords,
             interest.subscriptionsCount,
-            subscription.id.isNotNull(), // 내가 구독 중인지 여부
+            subscribedExpression,
             interest.createdAt
-            )
-        )
+        ))
         .from(interest)
-        .leftJoin(subscription)
-        .on(subscription.interest.id.eq(interest.id)
-            .and(subscription.user.id.eq(userId)))
         .where(builder)
-        .orderBy(primaryOrder, secondaryOrder)
+        .orderBy(primaryOrder, secondaryOrder, stabilityOrder)
         .limit(limit + 1)
         .fetch();
 
     boolean hasNext = results.size() > limit;
     if (hasNext) results.remove(limit);
 
-    // 커서 계산
     String nextCursor = hasNext ? results.get(results.size() - 1).id().toString() : null;
     Instant nextAfter = hasNext ? results.get(results.size() - 1).createdAt() : null;
 
@@ -82,6 +88,35 @@ public class InterestRepositoryCustomImpl implements InterestRepositoryCustom {
         results.size(),
         hasNext
     );
+  }
+
+  //유틸 메서드
+
+  private void extracted(String direction, String cursor, BooleanBuilder builder) {
+    Instant cursorCreatedAt = null;
+    if (cursor != null) {
+      UUID cursorId = UUID.fromString(cursor);
+
+      cursorCreatedAt = queryFactory
+          .select(interest.createdAt)
+          .from(interest)
+          .where(interest.id.eq(cursorId))
+          .fetchOne();
+
+      if (cursorCreatedAt != null) {
+        boolean isAsc = "ASC".equalsIgnoreCase(direction);
+
+        builder.and(
+            isAsc
+                ? interest.createdAt.gt(cursorCreatedAt)
+                .or(interest.createdAt.eq(cursorCreatedAt)
+                    .and(interest.id.gt(cursorId)))
+                : interest.createdAt.lt(cursorCreatedAt)
+                    .or(interest.createdAt.eq(cursorCreatedAt)
+                        .and(interest.id.lt(cursorId)))
+        );
+      }
+    }
   }
 
   @Override
@@ -102,21 +137,6 @@ public class InterestRepositoryCustomImpl implements InterestRepositoryCustom {
             Double.class, "similarity({0}, {1})", interest.name, name).desc())
         .limit(20)
         .fetch();
-  }
-
-  // 유틸 메서드
-
-  private BooleanExpression buildCursorCondition(String direction, String cursor, Instant after) {
-    if (cursor == null || after == null) return null;
-
-    UUID cursorId = UUID.fromString(cursor);
-    boolean isAsc = "ASC".equalsIgnoreCase(direction);
-
-    return isAsc
-        ? interest.createdAt.after(after)
-        .or(interest.createdAt.eq(after).and(interest.id.gt(cursorId)))
-        : interest.createdAt.before(after)
-            .or(interest.createdAt.eq(after).and(interest.id.lt(cursorId)));
   }
 
   private OrderSpecifier<?> getOrderSpecifier(String orderBy, String direction) {

--- a/monew/src/main/java/com/spring/monew/interest/service/impl/InterestServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/interest/service/impl/InterestServiceImpl.java
@@ -25,14 +25,14 @@ public class InterestServiceImpl implements InterestService {
   @Override
   @Transactional
   public InterestDto addInterest(InterestRegisterRequest registerRequest) {
-    List<String> similarNames = interestRepository.findSimilarNames(registerRequest.name(), 0.55);
+    List<String> similarNames = interestRepository.findSimilarNames(registerRequest.name(), 0.45);
 
     //예외 처리 필요 interests name exixsts
     if (interestRepository.existsByName(registerRequest.name())) {
-      throw new IllegalArgumentException("같은 이름 존재");
+      throw new IllegalArgumentException("같은 이름이 존재합니다.");
     }
     if(!similarNames.isEmpty()) {
-      throw new IllegalArgumentException("같은 이름 존재 [유사도 높은 이름]");
+      throw new IllegalArgumentException("유사도가 높은 이름이 존재합니다.");
     }
     
     Interest interest = interestRepository.save(

--- a/monew/src/main/java/com/spring/monew/subscription/controller/SubscriptionController.java
+++ b/monew/src/main/java/com/spring/monew/subscription/controller/SubscriptionController.java
@@ -19,13 +19,13 @@ public class SubscriptionController {
 
   @PostMapping("/{interestId}/subscriptions")
   public SubscriptionDto subscriptionAdd(@PathVariable UUID interestId,
-      @RequestHeader UUID userId) {
+      @RequestHeader(name = "Monew-Request-User-ID") UUID userId) {
     return subscriptionService.addSubscription(interestId, userId);
   }
 
   @DeleteMapping("/{interestId}/subscriptions")
   public void subscriptionRemove(@PathVariable UUID interestId,
-      @RequestHeader UUID userId) {
+      @RequestHeader(name = "Monew-Request-User-ID") UUID userId) {
     subscriptionService.removeSubscription(interestId, userId);
   }
 }

--- a/monew/src/main/resources/schema.sql
+++ b/monew/src/main/resources/schema.sql
@@ -150,3 +150,10 @@ CREATE TABLE notifications
         REFERENCES users (id)
         ON DELETE CASCADE ON UPDATE CASCADE
 );
+
+SELECT
+    name,
+    similarity(name, '스포츠 센터') AS sim
+FROM interests
+WHERE similarity(name, '스포츠 센터') > 0
+ORDER BY sim DESC;


### PR DESCRIPTION
## Issues
- closed #39 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 기존에 페이지네이션 처리가 이상하여 분석결과
cursor는 잘 불러오는데 보조 커서는 프론트쪽에서 안 보내줘서 보조커서 처리를 다른 방식으로 함.
-> 문제없이 잘 돌아감.

- 기존 논리 삭제 처리로직을 변경
## 📷 Screenshot

## 📚 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 매일 자정에 소프트 삭제된 댓글을 영구 삭제하는 자동 정리 스케줄러 추가
  * 런타임에서 삭제된 항목을 자동으로 제외하는 엔티티 필터 자동 적용 추가

* **Improvements**
  * 페이지네이션 및 커서 로직 안정성 향상(결과 정렬의 결정성 보장)
  * 좋아요/구독 상태 판별 로직을 쿼리 기반으로 개선
  * 관심사 추가 시 유사도 임계값 조정 및 오류 메시지 문구 개선

* **Chores**
  * 요청자 ID 헤더명 표준화 및 DB 스크립트 파일 포맷 소소한 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->