### PR TITLE
[fix] header값 유틸 메서드 사용해서 인증

### DIFF
--- a/monew/src/main/java/com/spring/monew/article/controller/ArticleController.java
+++ b/monew/src/main/java/com/spring/monew/article/controller/ArticleController.java
@@ -4,6 +4,7 @@ import com.spring.monew.article.controller.dto.response.ArticleDto;
 import com.spring.monew.article.controller.dto.response.CursorPageResponseArticleDto;
 import com.spring.monew.article.service.ArticleService;
 import com.spring.monew.auth.config.HeaderUserAuthentication;
+import com.spring.monew.common.util.RequestUserExtractor;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,20 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ArticleController {
 
   private final ArticleService articleService;
-
-  private UUID extractUserId(Principal principal) {
-    if (principal instanceof HeaderUserAuthentication auth) {
-      String userIdStr = (String) auth.getPrincipal();
-      if (userIdStr != null && !userIdStr.isBlank()) {
-        try {
-          return UUID.fromString(userIdStr);
-        } catch (IllegalArgumentException ignored) {
-          return null;
-        }
-      }
-    }
-    return null;
-  }
+  private final RequestUserExtractor userExtractor;
 
   @GetMapping
   @Operation(summary = "기사 목록 조회", description = "필터, 검색, 정렬 기능을 지원하는 페이지네이션 기사 목록 조회")
@@ -79,7 +67,7 @@ public class ArticleController {
 
       Principal principal
   ) {
-    UUID userId = extractUserId(principal);
+    UUID userId = userExtractor.extractUserId(principal);
 
     return articleService.getArticles(
         keyword,
@@ -105,7 +93,7 @@ public class ArticleController {
       @PathVariable UUID articleId,
       Principal principal
   ) {
-    UUID userId = extractUserId(principal);
+    UUID userId = userExtractor.extractUserId(principal);
 
     return articleService.getArticle(articleId, userId);
   }

--- a/monew/src/main/java/com/spring/monew/comment/controller/CommentController.java
+++ b/monew/src/main/java/com/spring/monew/comment/controller/CommentController.java
@@ -5,6 +5,8 @@ import com.spring.monew.comment.controller.dto.request.CommentUpdateRequest;
 import com.spring.monew.comment.controller.dto.response.CommentDto;
 import com.spring.monew.comment.controller.dto.response.CursorPageResponseCommentDto;
 import com.spring.monew.comment.service.CommentService;
+import com.spring.monew.common.util.RequestUserExtractor;
+import java.security.Principal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
   private final CommentService commentService;
+  private final RequestUserExtractor userExtractor;
 
   @PostMapping
   public CommentDto commentAdd(
@@ -40,17 +43,18 @@ public class CommentController {
       @RequestParam(required = false) String cursor,                // 커서 값
       @RequestParam(required = false) Instant after,                // 보조 커서(createdAt)
       @RequestParam(defaultValue = "50") int limit,                 // 페이지 크기
-      @RequestHeader(name = "Monew-Request-User-ID") UUID userId    // 헤더 값
+      Principal principal
   ) {
-
+    UUID userId = userExtractor.extractUserId(principal);
     return commentService.getComments(articleId, orderBy,
         direction, cursor, after, limit, userId);
   }
 
   @PatchMapping("/{commentId}")
   public CommentDto commentModify(@PathVariable UUID commentId,
-      @RequestHeader(name = "Monew-Request-User-ID") UUID userId,
+      Principal principal,
       @RequestBody CommentUpdateRequest updateRequest) {
+    UUID userId = userExtractor.extractUserId(principal);
     return commentService.modifyComment(commentId, userId, updateRequest);
   }
 

--- a/monew/src/main/java/com/spring/monew/commentlike/controller/CommentLikeController.java
+++ b/monew/src/main/java/com/spring/monew/commentlike/controller/CommentLikeController.java
@@ -2,6 +2,8 @@ package com.spring.monew.commentlike.controller;
 
 import com.spring.monew.commentlike.controller.dto.response.CommentLikeDto;
 import com.spring.monew.commentlike.service.CommentLikeService;
+import com.spring.monew.common.util.RequestUserExtractor;
+import java.security.Principal;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,16 +18,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CommentLikeController {
   private final CommentLikeService commentLikeService;
+  private final RequestUserExtractor userExtractor;
 
   @PostMapping("/{commentId}/comment-likes")
   public CommentLikeDto commentLikeAdd(@PathVariable UUID commentId,
-    @RequestHeader(name = "Monew-Request-User-ID") UUID userId){
+    Principal principal){
+    UUID userId = userExtractor.extractUserId(principal);
     return commentLikeService.addCommentLike(commentId, userId);
   }
 
   @DeleteMapping("/{commentId}/comment-likes")
   public void commentLikeDelete(@PathVariable UUID commentId,
-  @RequestHeader(name = "Monew-Request-User-ID") UUID userId){
+      Principal principal){
+    UUID userId = userExtractor.extractUserId(principal);
     commentLikeService.removeCommentLike(commentId, userId);
 
   }

--- a/monew/src/main/java/com/spring/monew/common/util/RequestUserExtractor.java
+++ b/monew/src/main/java/com/spring/monew/common/util/RequestUserExtractor.java
@@ -1,0 +1,25 @@
+package com.spring.monew.common.util;
+
+import com.spring.monew.auth.config.HeaderUserAuthentication;
+import java.security.Principal;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RequestUserExtractor {
+
+  public UUID extractUserId(Principal principal) {
+    if (principal instanceof HeaderUserAuthentication auth) {
+      String userIdStr = (String) auth.getPrincipal();
+      if (userIdStr != null && !userIdStr.isBlank()) {
+        try {
+          return UUID.fromString(userIdStr);
+        } catch (IllegalArgumentException ignored) {
+          return null;
+        }
+      }
+    }
+    return null;
+  }
+
+}

--- a/monew/src/main/java/com/spring/monew/common/util/TestUtil.java
+++ b/monew/src/main/java/com/spring/monew/common/util/TestUtil.java
@@ -1,5 +1,0 @@
-package com.spring.monew.common.util;
-
-public class TestUtil {
-
-}

--- a/monew/src/main/java/com/spring/monew/interest/controller/InterestController.java
+++ b/monew/src/main/java/com/spring/monew/interest/controller/InterestController.java
@@ -1,10 +1,12 @@
 package com.spring.monew.interest.controller;
 
+import com.spring.monew.common.util.RequestUserExtractor;
 import com.spring.monew.interest.controller.dto.request.InterestRegisterRequest;
 import com.spring.monew.interest.controller.dto.request.InterestUpdateRequest;
 import com.spring.monew.interest.controller.dto.response.CursorPageResponseInterestDto;
 import com.spring.monew.interest.controller.dto.response.InterestDto;
 import com.spring.monew.interest.service.InterestService;
+import java.security.Principal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class InterestController {
 
   private final InterestService interestService;
+  private final RequestUserExtractor userExtractor;
 
   @PostMapping
   public InterestDto interestAdd(@RequestBody InterestRegisterRequest registerRequest) {
@@ -39,8 +42,9 @@ public class InterestController {
       @RequestParam(required = false) String cursor,                // 커서 값
       @RequestParam(required = false) Instant after,                // 보조 커서(createdAt)
       @RequestParam(defaultValue = "50") int limit,                 // 페이지 크기
-      @RequestHeader(name = "Monew-Request-User-ID") UUID userId    // 헤더 값
+      Principal principal
   ) {
+    UUID userId = userExtractor.extractUserId(principal);
     return interestService.getInterests(keyword, orderBy, direction, cursor, after, limit, userId);
   }
 

--- a/monew/src/main/java/com/spring/monew/subscription/controller/SubscriptionController.java
+++ b/monew/src/main/java/com/spring/monew/subscription/controller/SubscriptionController.java
@@ -1,7 +1,9 @@
 package com.spring.monew.subscription.controller;
 
+import com.spring.monew.common.util.RequestUserExtractor;
 import com.spring.monew.subscription.controller.dto.response.SubscriptionDto;
 import com.spring.monew.subscription.service.SubscriptionService;
+import java.security.Principal;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,16 +18,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class SubscriptionController {
   private final SubscriptionService subscriptionService;
-
+  private final RequestUserExtractor userExtractor;
   @PostMapping("/{interestId}/subscriptions")
   public SubscriptionDto subscriptionAdd(@PathVariable UUID interestId,
-      @RequestHeader(name = "Monew-Request-User-ID") UUID userId) {
+      Principal principal) {
+
+    UUID userId = userExtractor.extractUserId(principal);
     return subscriptionService.addSubscription(interestId, userId);
   }
 
   @DeleteMapping("/{interestId}/subscriptions")
   public void subscriptionRemove(@PathVariable UUID interestId,
-      @RequestHeader(name = "Monew-Request-User-ID") UUID userId) {
+      Principal principal) {
+    UUID userId = userExtractor.extractUserId(principal);
     subscriptionService.removeSubscription(interestId, userId);
   }
 }

--- a/monew/src/test/java/com/spring/monew/commentlike/domain/CommentLikeServiceTest.java
+++ b/monew/src/test/java/com/spring/monew/commentlike/domain/CommentLikeServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.never;
 
 import com.spring.monew.article.domain.Article;
 import com.spring.monew.article.domain.ArticleSource;
-import com.spring.monew.article.repository.ArticleRepository;
 import com.spring.monew.comment.domain.Comment;
 import com.spring.monew.comment.repository.CommentRepository;
 import com.spring.monew.commentlike.controller.dto.response.CommentLikeDto;
@@ -66,7 +65,6 @@ class CommentLikeServiceTest {
         .willAnswer(invocation -> invocation.getArgument(0));
 
     // when
-    System.out.println(commentId + " : " + userId);
     CommentLikeDto result = commentLikeService.addCommentLike(commentId, userId);
 
     // then

--- a/monew/src/test/java/com/spring/monew/commentlike/service/CommentLikeIntegrationTest.java
+++ b/monew/src/test/java/com/spring/monew/commentlike/service/CommentLikeIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spring.monew.article.domain.Article;
 import com.spring.monew.article.domain.ArticleSource;
 import com.spring.monew.article.repository.ArticleRepository;
@@ -23,7 +22,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## Issues
- closed #61

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 유틸 메서드 넣었습니다.

## 📷 Screenshot
<img width="649" height="250" alt="{7C52FA7A-F3CC-4A27-BD5A-6BC67C3AF32B}" src="https://github.com/user-attachments/assets/805852d3-869d-408d-9330-0b0260c44468" />

사용하실때 Controller 단에서 RequestUserExtractor 선언하시고 
RequestHeader부분을 Principal로 변경하시면 됩니다.
## 📚 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 사용자 인증 처리 메커니즘을 중앙 집중식으로 개선했습니다.
  * 여러 API 엔드포인트에서 인증 기반 요청 처리 로직을 표준화했습니다.

* **Tests**
  * 테스트 코드의 불필요한 임포트 및 디버그 코드를 제거했습니다.

* **Chores**
  * 사용되지 않는 파일을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->