### PR TITLE
[feat] 활동 내역 기능 구현 및 MongoDB연동

### DIFF
--- a/monew/src/main/java/com/spring/monew/activity/controller/UserActivityController.java
+++ b/monew/src/main/java/com/spring/monew/activity/controller/UserActivityController.java
@@ -1,0 +1,46 @@
+package com.spring.monew.activity.controller;
+
+import com.spring.monew.activity.controller.dto.response.UserActivityDto;
+import com.spring.monew.activity.service.UserActivityService;
+import com.spring.monew.common.util.RequestUserExtractor;
+import io.swagger.v3.oas.annotations.Hidden;
+import java.security.Principal;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class UserActivityController {
+
+  private final UserActivityService userActivityService;
+  private final RequestUserExtractor userExtractor;
+
+  // 1) 내 활동내역 (헤더 없으면 401)
+  @Hidden
+  @GetMapping("/api/user-activities/me")
+  public ResponseEntity<UserActivityDto> myActivity(Principal principal) {
+    UUID userId = userExtractor.extractUserId(principal);
+    if (userId == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+    }
+    return ResponseEntity.ok(userActivityService.getUserActivity(userId));
+  }
+
+  // 2) 특정 사용자 활동내역 (헤더 없어도 허용, 있으면 불일치 시 403 선택 적용)
+  @GetMapping("/api/user-activities/{userId}")
+  public ResponseEntity<UserActivityDto> userActivityById(
+      @PathVariable UUID userId,
+      Principal principal
+  ) {
+    UUID reqUserId = userExtractor.extractUserId(principal);
+    return ResponseEntity.ok(userActivityService.getUserActivity(userId));
+  }
+}

--- a/monew/src/main/java/com/spring/monew/activity/controller/dto/response/UserActivityDto.java
+++ b/monew/src/main/java/com/spring/monew/activity/controller/dto/response/UserActivityDto.java
@@ -1,0 +1,71 @@
+package com.spring.monew.activity.controller.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(name = "UserActivityDto")
+public record UserActivityDto(
+    UUID id,
+    String email,
+    String nickname,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC") Instant createdAt,
+    List<Subscription> subscriptions,
+    List<Comment> comments,
+    List<CommentLike> commentLikes,
+    List<ArticleView> articleViews
+) {
+  @Schema(name = "UserActivityDto.Subscription")
+  public static record Subscription(
+      UUID id,
+      UUID interestId,
+      String interestName,
+      List<String> interestKeywords,
+      long interestSubscriberCount,
+      @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC") Instant createdAt
+  ) {}
+
+  @Schema(name = "UserActivityDto.Comment")
+  public static record Comment(
+      UUID id,
+      UUID articleId,
+      String articleTitle,
+      UUID userId,
+      String userNickname,
+      String content,
+      long likeCount,
+      @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC") Instant createdAt
+  ) {}
+
+  // 스웨거 예시와 맞춤: 내가 누른 좋아요 항목에서 '대상 댓글'의 스냅샷 정보 제공
+  @Schema(name = "UserActivityDto.CommentLike")
+  public static record CommentLike(
+      UUID id, // likeEventId
+      @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC") Instant createdAt,
+      UUID commentId,
+      UUID articleId,
+      String articleTitle,
+      UUID commentUserId,
+      String commentUserNickname,
+      String commentContent,
+      long commentLikeCount,
+      @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC") Instant commentCreatedAt
+  ) {}
+
+  @Schema(name = "UserActivityDto.ArticleView")
+  public static record ArticleView(
+      UUID id,
+      UUID viewedBy, // userId
+      @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC") Instant createdAt,
+      UUID articleId,
+      String source,
+      String sourceUrl,
+      String articleTitle,
+      @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC") Instant articlePublishedDate,
+      String articleSummary,
+      Long articleCommentCount,
+      Long articleViewCount
+  ) {}
+}

--- a/monew/src/main/java/com/spring/monew/activity/domain/ActivityArticleViewDoc.java
+++ b/monew/src/main/java/com/spring/monew/activity/domain/ActivityArticleViewDoc.java
@@ -1,0 +1,34 @@
+package com.spring.monew.activity.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Document("activity_article_views")
+@CompoundIndexes({
+    @CompoundIndex(name = "uk_view_user_article", def = "{'userId': 1, 'articleId': 1}", unique = true),
+    @CompoundIndex(name = "ix_view_user_lastViewed", def = "{'userId': 1, 'lastViewedAt': -1}")
+})
+public class ActivityArticleViewDoc {
+  @Id private String id;        // viewEventId (최초 삽입 시)
+  private UUID userId;
+  private UUID articleId;
+  private String source;
+  private String sourceUrl;
+  private String title;
+  private String summary;
+  private Long commentCount;
+  private Long viewCount;
+  private Instant publishDate;
+  private Instant createdAt;    // 최초 본 시각
+  private Instant lastViewedAt; // 최근 본 시각
+}

--- a/monew/src/main/java/com/spring/monew/activity/domain/ActivityCommentDoc.java
+++ b/monew/src/main/java/com/spring/monew/activity/domain/ActivityCommentDoc.java
@@ -1,0 +1,28 @@
+package com.spring.monew.activity.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Document("activity_comments")
+@CompoundIndexes({
+    @CompoundIndex(name = "uid_created_desc", def = "{userId:1, createdAt:-1, _id:-1}")
+})
+public class ActivityCommentDoc {
+  @Id private String id;
+  private UUID userId;
+  private UUID articleId;
+  private String articleTitle;
+  private String content;
+  private long likeCount;
+  private Instant createdAt;
+}

--- a/monew/src/main/java/com/spring/monew/activity/domain/ActivityCommentLikeDoc.java
+++ b/monew/src/main/java/com/spring/monew/activity/domain/ActivityCommentLikeDoc.java
@@ -1,0 +1,33 @@
+package com.spring.monew.activity.domain;
+
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Document("activity_comment_likes")
+@CompoundIndexes({
+    @CompoundIndex(name = "uid_created_desc", def = "{userId:1, createdAt:-1, _id:-1}")
+})
+public class ActivityCommentLikeDoc {
+  @Id private String id; // likeEventId
+  private UUID userId; // likedBy
+  private UUID commentId;
+  private UUID articleId;
+  private String articleTitle;
+  private UUID commentUserId;
+  private String commentUserNickname;
+  private String commentContent;
+  private long commentLikeCount;
+  private Instant commentCreatedAt;
+  private Instant createdAt; // like time
+}

--- a/monew/src/main/java/com/spring/monew/activity/domain/UserInterestSubscriptionDoc.java
+++ b/monew/src/main/java/com/spring/monew/activity/domain/UserInterestSubscriptionDoc.java
@@ -1,0 +1,56 @@
+package com.spring.monew.activity.domain;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Document("user_interest_subscriptions")
+@CompoundIndexes({
+    @CompoundIndex(
+        name = "uk_sub_user_interest",
+        def = "{'user_id': 1, 'interest_id': 1}",
+        unique = true,
+        // 유니크 인덱스는 UUID(binData)기반 문서만 대상으로 함
+        partialFilter = "{ 'user_id': { $type: 'binData' }, 'interest_id': { $type: 'binData' } }"
+    )
+})
+public class UserInterestSubscriptionDoc {
+
+    @Id
+    private String id;
+
+    @NotNull
+    @Field("user_id")
+    private UUID userId;
+
+    @NotNull
+    @Field("interest_id")
+    private UUID interestId;
+
+    @Field("interest_name")
+    private String interestName;
+
+    @Field("interest_keywords")
+    private List<String> interestKeywords;
+
+    @PositiveOrZero
+    @Field("interest_subscriber_count")
+    private long interestSubscriberCount;
+
+    @NotNull
+    @Field("created_at")
+    private Instant createdAt;
+}

--- a/monew/src/main/java/com/spring/monew/activity/repository/ActivitySyncRepository.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/ActivitySyncRepository.java
@@ -1,0 +1,75 @@
+package com.spring.monew.activity.repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public interface ActivitySyncRepository {
+
+  // ===== 구독 =====
+  void onSubscribed(
+      UUID subscriptionId,
+      UUID userId,
+      UUID interestId,
+      String interestName,
+      List<String> interestKeywords,
+      long interestSubscriberCount,
+      Instant createdAt
+  );
+
+  void onUnsubscribed(UUID subscriptionId);
+  void onUnsubscribed(UUID userId, UUID interestId);
+
+  // ===== 댓글 =====
+  void onCommentCreated(
+      UUID commentId,
+      UUID userId,
+      UUID articleId,
+      String articleTitle,
+      String commentUserNickname,
+      String content,
+      long likeCount,
+      Instant createdAt
+  );
+
+  void onCommentDeleted(UUID commentId);
+  void onCommentDeleted(UUID commentId, Instant deletedAt);
+
+  // ===== 댓글 좋아요 =====
+  void onCommentLiked(
+      UUID likeEventId,
+      UUID userId,                // likedBy
+      UUID commentId,
+      UUID articleId,
+      String articleTitle,
+      UUID commentUserId,
+      String commentUserNickname,
+      String commentContent,
+      long commentLikeCount,
+      Instant commentCreatedAt,
+      Instant likeCreatedAt
+  );
+
+  // 호환용 1-파라미터 → 2-파라미터로 위임
+  default void onCommentLikeCanceled(UUID likeEventId) {
+    onCommentLikeCanceled(likeEventId, null);
+  }
+
+  // 실제 구현해야 할 시그니처(필요시 userId 전달)
+  void onCommentLikeCanceled(UUID likeEventId, UUID userId);
+
+  // ===== 기사 열람(최근 본 기사) =====
+  void onArticleViewed(
+      UUID viewEventId,
+      UUID userId,
+      UUID articleId,
+      String source,
+      String sourceUrl,
+      String articleTitle,
+      Instant articlePublishedDate,
+      String articleSummary,
+      Long articleCommentCount,
+      Long articleViewCount,
+      Instant createdAt
+  );
+}

--- a/monew/src/main/java/com/spring/monew/activity/repository/UserActivityQueryRepository.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/UserActivityQueryRepository.java
@@ -1,0 +1,25 @@
+package com.spring.monew.activity.repository;
+
+import com.spring.monew.activity.controller.dto.response.UserActivityDto;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+//활동 내역 조회 전용 리포지토리(읽기 모델).
+
+public interface UserActivityQueryRepository {
+
+  // RDB에서 사용자 요약 정보만 조회
+  record UserSummary(UUID id, String email, String nickname, Instant createdAt) {}
+
+  Optional<UserSummary> findUserSummary(UUID userId);
+
+  List<UserActivityDto.Subscription> findTopSubscriptions(UUID userId, int topN);
+
+  List<UserActivityDto.Comment> findTopComments(UUID userId, int topN);
+
+  List<UserActivityDto.CommentLike> findTopCommentLikes(UUID userId, int topN);
+
+  List<UserActivityDto.ArticleView> findTopArticleViews(UUID userId, int topN);
+}

--- a/monew/src/main/java/com/spring/monew/activity/repository/impl/ActivitySyncRepositoryImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/impl/ActivitySyncRepositoryImpl.java
@@ -1,0 +1,203 @@
+package com.spring.monew.activity.repository.impl;
+
+import com.mongodb.client.result.UpdateResult;
+import com.spring.monew.activity.domain.ActivityArticleViewDoc;
+import com.spring.monew.activity.domain.ActivityCommentDoc;
+import com.spring.monew.activity.domain.ActivityCommentLikeDoc;
+import com.spring.monew.activity.domain.UserInterestSubscriptionDoc;
+import com.spring.monew.activity.repository.ActivitySyncRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class ActivitySyncRepositoryImpl implements ActivitySyncRepository {
+
+  private final MongoTemplate mongo;
+
+  // ====== 구독 ======
+  @Override
+  public void onSubscribed(UUID subscriptionId, UUID userId, UUID interestId, String interestName,
+      List<String> interestKeywords, long interestSubscriberCount, Instant createdAt) {
+    if (subscriptionId == null || userId == null || interestId == null) {
+      log.warn("onSubscribed skipped: subscriptionId={}, userId={}, interestId={}", subscriptionId, userId, interestId);
+      return;
+    }
+    Update up = new Update()
+        .set("user_id", userId)
+        .set("interest_id", interestId)
+        .set("interest_name", interestName)
+        .set("interest_keywords", interestKeywords)
+        .set("interest_subscriber_count", interestSubscriberCount)
+        .set("created_at", createdAt);
+
+    UpdateResult r = mongo.upsert(
+        Query.query(Criteria.where("_id").is(subscriptionId.toString())),
+        up, UserInterestSubscriptionDoc.class
+    );
+    log.info("onSubscribed -> matched={}, modified={}, upsertedId={}", r.getMatchedCount(), r.getModifiedCount(), r.getUpsertedId());
+
+    if (r.getMatchedCount() == 0 && r.getUpsertedId() == null) {
+      Query legacyKey = Query.query(
+          Criteria.where("user_id").in(userId, userId.toString())
+              .and("interest_id").in(interestId, interestId.toString())
+      );
+      up.setOnInsert("_id", subscriptionId.toString());
+      UpdateResult r2 = mongo.upsert(legacyKey, up, UserInterestSubscriptionDoc.class);
+      log.info("onSubscribed[legacy-fallback] -> matched={}, modified={}, upsertedId={}",
+          r2.getMatchedCount(), r2.getModifiedCount(), r2.getUpsertedId());
+    }
+  }
+
+  @Override
+  public void onUnsubscribed(UUID subscriptionId) {
+    mongo.remove(Query.query(Criteria.where("_id").is(subscriptionId.toString())),
+        UserInterestSubscriptionDoc.class);
+  }
+
+  @Override
+  public void onUnsubscribed(UUID userId, UUID interestId) {
+    Query q = Query.query(
+        Criteria.where("user_id").in(userId, userId.toString())
+            .and("interest_id").in(interestId, interestId.toString())
+    );
+    mongo.remove(q, UserInterestSubscriptionDoc.class);
+  }
+
+  // ====== 댓글 ======
+  @Override
+  public void onCommentCreated(UUID commentId, UUID userId, UUID articleId, String articleTitle,
+      String commentUserNickname, String content, long likeCount, Instant createdAt) {
+    Update up = new Update()
+        .set("userId", userId)
+        .set("articleId", articleId)
+        .set("articleTitle", articleTitle)
+        .set("content", content)
+        .set("likeCount", likeCount)
+        .set("createdAt", createdAt);
+
+    mongo.upsert(
+        Query.query(Criteria.where("_id").is(commentId.toString())),
+        up,
+        ActivityCommentDoc.class
+    );
+  }
+
+  @Override
+  public void onCommentDeleted(UUID commentId) {
+    mongo.remove(
+        Query.query(Criteria.where("_id").is(commentId.toString())),
+        ActivityCommentDoc.class
+    );
+  }
+
+  @Override
+  public void onCommentDeleted(UUID commentId, Instant deletedAt) {
+    onCommentDeleted(commentId); // deletedAt은 현재 미사용
+  }
+
+  // ====== 댓글 좋아요 ======
+  @Override
+  public void onCommentLiked(UUID likeEventId, UUID userId, UUID commentId, UUID articleId, String articleTitle,
+      UUID commentUserId, String commentUserNickname, String commentContent,
+      long commentLikeCount, Instant commentCreatedAt, Instant likeCreatedAt) {
+
+    // 1) 좋아요 이벤트 upsert
+    Update up = new Update()
+        .set("userId", userId) // likedBy
+        .set("commentId", commentId)
+        .set("articleId", articleId)
+        .set("articleTitle", articleTitle)
+        .set("commentUserId", commentUserId)
+        .set("commentUserNickname", commentUserNickname)
+        .set("commentContent", commentContent)
+        .set("commentLikeCount", commentLikeCount)
+        .set("commentCreatedAt", commentCreatedAt)
+        .set("createdAt", likeCreatedAt);
+
+    mongo.upsert(
+        Query.query(Criteria.where("_id").is(likeEventId.toString())),
+        up,
+        ActivityCommentLikeDoc.class
+    );
+
+    // 2) 댓글 스냅샷의 likeCount 를 정답 스냅샷 값으로 동기화
+    Query q = Query.query(Criteria.where("_id").is(commentId.toString()));
+    Update sync = new Update()
+        .set("likeCount", commentLikeCount)
+        .set("lastLikedAt", likeCreatedAt);
+    mongo.updateFirst(q, sync, ActivityCommentDoc.class);
+  }
+
+  @Override
+  public void onCommentLikeCanceled(UUID likeId, UUID userId) {
+    // 1) 어떤 댓글의 좋아요인지 먼저 조회
+    ActivityCommentLikeDoc likeDoc =
+        mongo.findById(likeId.toString(), ActivityCommentLikeDoc.class);
+
+    // 2) like 문서 삭제
+    mongo.remove(
+        Query.query(Criteria.where("_id").is(likeId.toString())),
+        ActivityCommentLikeDoc.class
+    );
+
+    // 3) 댓글 스냅샷의 likeCount 감소 (하한 0 보정)
+    if (likeDoc != null && likeDoc.getCommentId() != null) {
+      String commentKey = likeDoc.getCommentId().toString();
+
+      // 3-1) 우선 1 감소
+      Query q = Query.query(Criteria.where("_id").is(commentKey));
+      Update dec = new Update().inc("likeCount", -1);
+      mongo.updateFirst(q, dec, ActivityCommentDoc.class);
+
+      // 3-2) 음수 방지
+      Query fixNeg = Query.query(
+          new Criteria().andOperator(
+              Criteria.where("_id").is(commentKey),
+              Criteria.where("likeCount").lt(0)
+          )
+      );
+      Update zero = new Update().set("likeCount", 0);
+      mongo.updateFirst(fixNeg, zero, ActivityCommentDoc.class);
+    }
+  }
+
+  // ====== 기사 열람 ======
+  @Override
+  public void onArticleViewed(UUID viewEventId, UUID userId, UUID articleId, String source, String sourceUrl,
+      String articleTitle, Instant articlePublishedDate, String articleSummary,
+      Long articleCommentCount, Long articleViewCount, Instant createdAt) {
+
+    Update up = new Update()
+        // view doc은 (userId+articleId) 기준 upsert이므로 _id 세팅은 하지 않음
+        .set("userId", userId)
+        .set("articleId", articleId)
+        .set("source", source)
+        .set("sourceUrl", sourceUrl)
+        .set("title", articleTitle)
+        .set("summary", articleSummary)
+        .set("commentCount", articleCommentCount)
+        .set("viewCount", articleViewCount)
+        .set("publishDate", articlePublishedDate)
+        .setOnInsert("createdAt", createdAt)
+        .set("lastViewedAt", createdAt);
+
+    Query q = Query.query(
+        Criteria.where("userId").is(userId)
+            .and("articleId").is(articleId)
+    );
+
+    UpdateResult result = mongo.upsert(q, up, ActivityArticleViewDoc.class);
+    log.debug("activity_article_views upsert matched={}, modified={}, upsertedId={}",
+        result.getMatchedCount(), result.getModifiedCount(), result.getUpsertedId());
+  }
+}

--- a/monew/src/main/java/com/spring/monew/activity/repository/impl/ActivitySyncRepositoryImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/impl/ActivitySyncRepositoryImpl.java
@@ -178,6 +178,7 @@ public class ActivitySyncRepositoryImpl implements ActivitySyncRepository {
       Long articleCommentCount, Long articleViewCount, Instant createdAt) {
 
     Update up = new Update()
+        .setOnInsert("_id", viewEventId.toString())
         // view doc은 (userId+articleId) 기준 upsert이므로 _id 세팅은 하지 않음
         .set("userId", userId)
         .set("articleId", articleId)

--- a/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
@@ -1,0 +1,130 @@
+package com.spring.monew.activity.repository.impl;
+
+import static org.springframework.data.domain.Sort.Order.desc;
+import com.spring.monew.activity.controller.dto.response.UserActivityDto;
+import com.spring.monew.activity.domain.ActivityArticleViewDoc;
+import com.spring.monew.activity.domain.ActivityCommentDoc;
+import com.spring.monew.activity.domain.ActivityCommentLikeDoc;
+import com.spring.monew.activity.domain.UserInterestSubscriptionDoc;
+import com.spring.monew.activity.repository.UserActivityQueryRepository;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserActivityQueryRepositoryImpl implements UserActivityQueryRepository {
+
+  private final MongoTemplate mongo;
+  private final JdbcTemplate jdbc;
+
+  @Override
+  public Optional<UserSummary> findUserSummary(UUID userId) {
+    try {
+      return Optional.ofNullable(
+          jdbc.queryForObject(
+              "SELECT id, email, nickname, created_at FROM users WHERE id = ?",
+              (rs, rowNum) -> new UserSummary(
+                  uuid(rs, "id"), rs.getString("email"), rs.getString("nickname"),
+                  rs.getTimestamp("created_at") != null
+                      ? rs.getTimestamp("created_at").toInstant()
+                      : Instant.now()
+              ),
+              userId
+          )
+      );
+    } catch (EmptyResultDataAccessException e) {
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public List<UserActivityDto.Subscription> findTopSubscriptions(UUID userId, int topN) {
+    Query q = new Query();
+    q.addCriteria(Criteria.where("userId").is(userId));
+    q.with(Sort.by(desc("createdAt"), desc("_id")));
+    q.limit(topN);
+    List<UserInterestSubscriptionDoc> docs = mongo.find(q, UserInterestSubscriptionDoc.class);
+    List<UserActivityDto.Subscription> out = new ArrayList<UserActivityDto.Subscription>(docs.size());
+    for (UserInterestSubscriptionDoc d : docs) {
+      out.add(new UserActivityDto.Subscription(
+          UUID.fromString(d.getId()), d.getInterestId(), d.getInterestName(),
+          d.getInterestKeywords(), d.getInterestSubscriberCount(), d.getCreatedAt()
+      ));
+    }
+    return out;
+  }
+
+  @Override
+  public List<UserActivityDto.Comment> findTopComments(UUID userId, int topN) {
+    Query q = new Query();
+    q.addCriteria(Criteria.where("userId").is(userId));
+    q.with(Sort.by(desc("createdAt"), desc("_id")));
+    q.limit(topN);
+    List<ActivityCommentDoc> docs = mongo.find(q, ActivityCommentDoc.class);
+    List<UserActivityDto.Comment> out = new ArrayList<UserActivityDto.Comment>(docs.size());
+    for (ActivityCommentDoc d : docs) {
+      out.add(new UserActivityDto.Comment(
+          UUID.fromString(d.getId()), d.getArticleId(), d.getArticleTitle(),
+          d.getUserId(), null, d.getContent(), d.getLikeCount(), d.getCreatedAt()
+      ));
+    }
+    return out;
+  }
+
+  @Override
+  public List<UserActivityDto.CommentLike> findTopCommentLikes(UUID userId, int topN) {
+    Query q = new Query();
+    q.addCriteria(Criteria.where("userId").is(userId));
+    q.with(Sort.by(desc("createdAt"), desc("_id")));
+    q.limit(topN);
+    List<ActivityCommentLikeDoc> docs = mongo.find(q, ActivityCommentLikeDoc.class);
+    List<UserActivityDto.CommentLike> out = new ArrayList<UserActivityDto.CommentLike>(docs.size());
+    for (ActivityCommentLikeDoc d : docs) {
+      out.add(new UserActivityDto.CommentLike(
+          UUID.fromString(d.getId()), d.getCreatedAt(), d.getCommentId(), d.getArticleId(), d.getArticleTitle(),
+          d.getCommentUserId(), d.getCommentUserNickname(), d.getCommentContent(), d.getCommentLikeCount(), d.getCommentCreatedAt()
+      ));
+    }
+    return out;
+  }
+
+  // article views
+  @Override
+  public List<UserActivityDto.ArticleView> findTopArticleViews(UUID userId, int topN) {
+    Query q = new Query();
+    q.addCriteria(Criteria.where("userId").is(userId));
+    q.with(Sort.by(desc("createdAt"), desc("_id")));
+    q.limit(topN);
+    List<ActivityArticleViewDoc> docs = mongo.find(q, ActivityArticleViewDoc.class);
+    List<UserActivityDto.ArticleView> out = new ArrayList<UserActivityDto.ArticleView>(docs.size());
+    for (ActivityArticleViewDoc d : docs) {
+      out.add(new UserActivityDto.ArticleView(
+          UUID.fromString(d.getId()), d.getUserId(), d.getCreatedAt(), d.getArticleId(), d.getSource(), d.getSourceUrl(),
+          d.getTitle(), d.getPublishDate(), d.getSummary(), d.getCommentCount(), d.getViewCount()
+      ));
+    }
+    return out;
+  }
+
+  private static UUID uuid(ResultSet rs, String col) throws SQLException {
+    Object obj = rs.getObject(col);
+    if (obj instanceof UUID) {
+      return (UUID) obj;
+    }
+    return UUID.fromString(Objects.toString(obj));
+  }
+}

--- a/monew/src/main/java/com/spring/monew/activity/service/UserActivityService.java
+++ b/monew/src/main/java/com/spring/monew/activity/service/UserActivityService.java
@@ -1,0 +1,8 @@
+package com.spring.monew.activity.service;
+
+import com.spring.monew.activity.controller.dto.response.UserActivityDto;
+import java.util.UUID;
+
+public interface UserActivityService {
+  UserActivityDto getUserActivity(UUID userId);
+}

--- a/monew/src/main/java/com/spring/monew/activity/service/impl/UserActivityServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/service/impl/UserActivityServiceImpl.java
@@ -1,0 +1,36 @@
+package com.spring.monew.activity.service.impl;
+
+import com.spring.monew.activity.controller.dto.response.UserActivityDto;
+import com.spring.monew.activity.repository.UserActivityQueryRepository;
+import com.spring.monew.activity.repository.UserActivityQueryRepository.UserSummary;
+import com.spring.monew.activity.service.UserActivityService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserActivityServiceImpl implements UserActivityService {
+
+  private static final int TOP_N = 10;
+  private final UserActivityQueryRepository repo;
+
+  @Override
+  @Transactional(readOnly = true)
+  public UserActivityDto getUserActivity(UUID userId) {
+    UserSummary u = repo.findUserSummary(userId)
+        .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+    List<UserActivityDto.Subscription> subs = repo.findTopSubscriptions(userId, TOP_N);
+    List<UserActivityDto.Comment> comments = repo.findTopComments(userId, TOP_N);
+    List<UserActivityDto.CommentLike> likes = repo.findTopCommentLikes(userId, TOP_N);
+    List<UserActivityDto.ArticleView> views = repo.findTopArticleViews(userId, TOP_N);
+
+    return new UserActivityDto(
+        u.id(), u.email(), u.nickname(), u.createdAt(),
+        subs, comments, likes, views
+    );
+  }
+}

--- a/monew/src/main/java/com/spring/monew/comment/service/impl/CommentServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/comment/service/impl/CommentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.spring.monew.comment.service.impl;
 
+import com.spring.monew.activity.repository.ActivitySyncRepository;
 import com.spring.monew.article.domain.Article;
 import com.spring.monew.article.repository.ArticleRepository;
 import com.spring.monew.comment.controller.dto.request.CommentRegisterRequest;
@@ -15,9 +16,11 @@ import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -26,6 +29,7 @@ public class CommentServiceImpl implements CommentService {
   private final CommentRepository commentRepository;
   private final UserRepository userRepository;
   private final ArticleRepository articleRepository;
+  private final ActivitySyncRepository activitySyncRepository;
 
   @Override
   @Transactional
@@ -37,6 +41,22 @@ public class CommentServiceImpl implements CommentService {
         () -> new NoSuchElementException("존재하지 않는 기사입니다."));
 
     Comment comment = commentRepository.save(new Comment(article, user, registerRequest.content()));
+
+    try {
+      activitySyncRepository.onCommentCreated(
+          comment.getId(),
+          user.getId(),
+          article.getId(),
+          article.getTitle(),
+          user.getNickname(),
+          comment.getContent(),
+          comment.getLikeCount(),
+          comment.getCreatedAt()
+      );
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (댓글 생성): commentId={}, userId={}, articleId={}",
+          comment.getId(), user.getId(), article.getId(), e);
+    }
 
     return new CommentDto(
         comment.getId(),
@@ -72,6 +92,25 @@ public class CommentServiceImpl implements CommentService {
 
     comment.update(updateRequest.content());
 
+    Article article = comment.getArticle();
+    User writer = comment.getUser();
+
+    try {
+      activitySyncRepository.onCommentCreated(
+          comment.getId(),
+          writer.getId(),
+          article.getId(),
+          article.getTitle(),
+          writer.getNickname(),
+          comment.getContent(),
+          comment.getLikeCount(),
+          comment.getCreatedAt()
+      );
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (댓글 수정→스냅샷 갱신): commentId={}, userId={}, articleId={}",
+          comment.getId(), writer.getId(), article.getId(), e);
+    }
+
     return new CommentDto(
         comment.getId(),
         comment.getArticle().getId(),
@@ -92,6 +131,10 @@ public class CommentServiceImpl implements CommentService {
     }
 
     commentRepository.deleteById(commentId);
+
+    try {
+      activitySyncRepository.onCommentDeleted(commentId, Instant.now());
+    } catch (Exception ignore) {}
   }
 
   @Override
@@ -102,5 +145,10 @@ public class CommentServiceImpl implements CommentService {
     }
 
     commentRepository.deletePhysicalById(commentId);
+    try {
+      activitySyncRepository.onCommentDeleted(commentId, Instant.now());
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (댓글 물리 삭제): commentId={}", commentId, e);
+    }
   }
 }

--- a/monew/src/main/java/com/spring/monew/commentlike/service/impl/CommentLikeServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/commentlike/service/impl/CommentLikeServiceImpl.java
@@ -1,5 +1,6 @@
 package com.spring.monew.commentlike.service.impl;
 
+import com.spring.monew.activity.repository.ActivitySyncRepository;
 import com.spring.monew.comment.domain.Comment;
 import com.spring.monew.comment.repository.CommentRepository;
 import com.spring.monew.commentlike.controller.dto.response.CommentLikeDto;
@@ -7,6 +8,8 @@ import com.spring.monew.commentlike.domain.CommentLike;
 import com.spring.monew.commentlike.repository.CommentLikeRepository;
 import com.spring.monew.commentlike.service.CommentLikeService;
 import com.spring.monew.interest.domain.Interest;
+import com.spring.monew.notification.domain.NotificationResourceType;
+import com.spring.monew.notification.service.NotificationService;
 import com.spring.monew.subscription.domain.Subscription;
 import com.spring.monew.user.domain.User;
 import com.spring.monew.user.repository.UserRepository;
@@ -14,9 +17,11 @@ import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -25,6 +30,8 @@ public class CommentLikeServiceImpl implements CommentLikeService {
   private final CommentLikeRepository commentLikeRepository;
   private final CommentRepository commentRepository;
   private final UserRepository userRepository;
+  private final ActivitySyncRepository activitySyncRepository;
+  private final NotificationService notificationService;
 
   @Override
   @Transactional
@@ -43,6 +50,36 @@ public class CommentLikeServiceImpl implements CommentLikeService {
     comment.incrementLikeCount();
 
     CommentLike commentLike = commentLikeRepository.save(new CommentLike(comment, user));
+
+    try {
+      activitySyncRepository.onCommentLiked(
+          commentLike.getId(),                // likeEventId
+          user.getId(),                       // likedByUserId
+          comment.getId(),                    // commentId
+          comment.getArticle().getId(),       // articleId
+          comment.getArticle().getTitle(),    // articleTitleSnapshot
+          comment.getUser().getId(),          // commentUserId
+          comment.getUser().getNickname(),    // commentUserNicknameSnapshot
+          comment.getContent(),               // commentContentSnapshot
+          comment.getLikeCount(),             // commentLikeCountSnapshot
+          comment.getCreatedAt(),             // commentCreatedAtSnapshot
+          commentLike.getCreatedAt()          // likedAt
+      );
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (댓글 좋아요 생성): likeId={}, commentId={}, likedByUserId={}, articleId={}",
+          commentLike.getId(), comment.getId(), user.getId(), comment.getArticle().getId(), e);
+    }
+
+    UUID commentAuthorId = comment.getUser().getId();
+    if (!commentAuthorId.equals(userId)) {
+      String content = user.getNickname() + "님이 나의 댓글을 좋아합니다.";
+      notificationService.create(
+          commentAuthorId,
+          content,
+          NotificationResourceType.COMMENT, // 관련 리소스 = 댓글
+          comment.getId()
+      );
+    }
 
     return new CommentLikeDto(
         commentLike.getId(),
@@ -66,6 +103,13 @@ public class CommentLikeServiceImpl implements CommentLikeService {
         .orElseThrow(() -> new NoSuchElementException("존재하지 않는 좋아요 입니다"));
 
     commentLike.getComment().decrementLikeCount();
+
+    try {
+      activitySyncRepository.onCommentLikeCanceled(commentLike.getId());
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (댓글 좋아요 취소): likeId={}, commentId={}, userId={}",
+          commentLike.getId(), commentId, userId, e);
+    }
 
     commentLikeRepository.delete(commentLike);
   }

--- a/monew/src/main/java/com/spring/monew/commentlike/service/impl/CommentLikeServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/commentlike/service/impl/CommentLikeServiceImpl.java
@@ -61,9 +61,9 @@ public class CommentLikeServiceImpl implements CommentLikeService {
           comment.getUser().getId(),          // commentUserId
           comment.getUser().getNickname(),    // commentUserNicknameSnapshot
           comment.getContent(),               // commentContentSnapshot
-          comment.getLikeCount(),             // commentLikeCountSnapshot
-          comment.getCreatedAt(),             // commentCreatedAtSnapshot
-          commentLike.getCreatedAt()          // likedAt
+          comment.getLikeCount(),             // commentLikeCountSnapshot (long)
+          comment.getCreatedAt(),             // commentCreatedAtSnapshot (Instant)
+          commentLike.getCreatedAt()          // likedAt (Instant)
       );
     } catch (Exception e) {
       log.warn("활동 동기화 실패 (댓글 좋아요 생성): likeId={}, commentId={}, likedByUserId={}, articleId={}",

--- a/monew/src/main/java/com/spring/monew/subscription/service/impl/SubscriptionServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/subscription/service/impl/SubscriptionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.spring.monew.subscription.service.impl;
 
+import com.spring.monew.activity.repository.ActivitySyncRepository;
 import com.spring.monew.interest.domain.Interest;
 import com.spring.monew.interest.repository.InterestRepository;
 import com.spring.monew.subscription.controller.dto.response.SubscriptionDto;
@@ -13,9 +14,11 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -24,6 +27,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
   private final SubscriptionRepository subscriptionRepository;
   private final UserRepository userRepository;
   private final InterestRepository interestRepository;
+  private final ActivitySyncRepository activitySyncRepository;
 
   @Override
   @Transactional
@@ -41,6 +45,22 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     interest.incrementSubscriptionsCount();
 
     Subscription subscription = subscriptionRepository.save(new Subscription(user, interest));
+
+    try {
+      activitySyncRepository.onSubscribed(
+          subscription.getId(),
+          user.getId(),
+          interest.getId(),
+          interest.getName(),
+          interest.getKeywords(),
+          subscriptionRepository.countByInterest_Id(interest.getId()),
+          subscription.getCreatedAt()
+      );
+    } catch (Exception e) {
+      // 실패 시 본 기능은 유지하고 경고 로그 + 스택트레이스 남김
+      log.warn("활동 동기화 실패 (구독 생성): subscriptionId={}, userId={}, interestId={}",
+          subscription.getId(), user.getId(), interest.getId(), e);
+    }
 
     return new SubscriptionDto(
         subscription.getId(),
@@ -62,5 +82,11 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     subscription.getInterest().decrementSubscriptionsCount();
 
     subscriptionRepository.delete(subscription);
+    try {
+      activitySyncRepository.onUnsubscribed(subscription.getId());
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (구독 해제): subscriptionId={}, userId={}, interestId={}",
+          subscription.getId(), userId, interestId, e);
+    }
   }
 }

--- a/monew/src/main/java/com/spring/monew/subscription/service/impl/SubscriptionServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/subscription/service/impl/SubscriptionServiceImpl.java
@@ -53,7 +53,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
           interest.getId(),
           interest.getName(),
           interest.getKeywords(),
-          subscriptionRepository.countByInterest_Id(interest.getId()),
+          interest.getSubscriptionsCount(),
           subscription.getCreatedAt()
       );
     } catch (Exception e) {


### PR DESCRIPTION
## Issues
- closed #38 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

- [x] 활동 내역 3가지(최근 작성한 댓글, 최근 좋아요한 댓글, 구독한 관심사)

## 📷 Screenshot

## 📚 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 활동 추적 시스템 추가: 구독, 댓글, 댓글 좋아요, 기사 조회 기록 자동 저장
  * 개인 활동 히스토리 조회: 최근 활동 10개까지 요약된 형태로 확인 가능한 새로운 API 엔드포인트 제공
  * 실시간 활동 동기화: 모든 사용자 활동이 즉시 기록되고 조회 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->