### PR TITLE
[feat] 활동 내역 -> 알림 (feture/#72로 진행)

### DIFF
--- a/monew/src/main/java/com/spring/monew/activity/controller/UserActivityController.java
+++ b/monew/src/main/java/com/spring/monew/activity/controller/UserActivityController.java
@@ -34,13 +34,20 @@ public class UserActivityController {
     return ResponseEntity.ok(userActivityService.getUserActivity(userId));
   }
 
-  // 2) 특정 사용자 활동내역 (헤더 없어도 허용, 있으면 불일치 시 403 선택 적용)
+  // 2) 특정 사용자 활동내역
   @GetMapping("/api/user-activities/{userId}")
   public ResponseEntity<UserActivityDto> userActivityById(
       @PathVariable UUID userId,
       Principal principal
   ) {
+    // 헤더가 없으면 null을 반환하도록 구현되어 있어야 합니다.
     UUID reqUserId = userExtractor.extractUserId(principal);
+    // 헤더가 있을 때만 소유자 검증
+    if (reqUserId != null && !reqUserId.equals(userId)) {
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN, "다른 사용자의 활동 내역을 조회할 수 없습니다."
+      );
+    }
     return ResponseEntity.ok(userActivityService.getUserActivity(userId));
   }
 }

--- a/monew/src/main/java/com/spring/monew/activity/controller/UserActivityController.java
+++ b/monew/src/main/java/com/spring/monew/activity/controller/UserActivityController.java
@@ -1,0 +1,46 @@
+package com.spring.monew.activity.controller;
+
+import com.spring.monew.activity.controller.dto.response.UserActivityDto;
+import com.spring.monew.activity.service.UserActivityService;
+import com.spring.monew.common.util.RequestUserExtractor;
+import io.swagger.v3.oas.annotations.Hidden;
+import java.security.Principal;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class UserActivityController {
+
+  private final UserActivityService userActivityService;
+  private final RequestUserExtractor userExtractor;
+
+  // 1) 내 활동내역 (헤더 없으면 401)
+  @Hidden
+  @GetMapping("/api/user-activities/me")
+  public ResponseEntity<UserActivityDto> myActivity(Principal principal) {
+    UUID userId = userExtractor.extractUserId(principal);
+    if (userId == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+    }
+    return ResponseEntity.ok(userActivityService.getUserActivity(userId));
+  }
+
+  // 2) 특정 사용자 활동내역 (헤더 없어도 허용, 있으면 불일치 시 403 선택 적용)
+  @GetMapping("/api/user-activities/{userId}")
+  public ResponseEntity<UserActivityDto> userActivityById(
+      @PathVariable UUID userId,
+      Principal principal
+  ) {
+    UUID reqUserId = userExtractor.extractUserId(principal);
+    return ResponseEntity.ok(userActivityService.getUserActivity(userId));
+  }
+}

--- a/monew/src/main/java/com/spring/monew/activity/controller/dto/response/UserActivityDto.java
+++ b/monew/src/main/java/com/spring/monew/activity/controller/dto/response/UserActivityDto.java
@@ -65,7 +65,7 @@ public record UserActivityDto(
       String articleTitle,
       @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC") Instant articlePublishedDate,
       String articleSummary,
-      Long articleCommentCount,
-      Long articleViewCount
+      long commentCount,
+      long viewCount
   ) {}
 }

--- a/monew/src/main/java/com/spring/monew/activity/domain/ActivityCommentDoc.java
+++ b/monew/src/main/java/com/spring/monew/activity/domain/ActivityCommentDoc.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 @Data
 @NoArgsConstructor
@@ -25,4 +26,6 @@ public class ActivityCommentDoc {
     private String content;
     private long likeCount;
     private Instant createdAt;
+    @Field("user_nickname")
+    private String userNickname;
 }

--- a/monew/src/main/java/com/spring/monew/activity/repository/ActivitySyncRepository.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/ActivitySyncRepository.java
@@ -4,8 +4,57 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-
 public interface ActivitySyncRepository {
 
+  // ===== 구독 =====
+  void onSubscribed(
+      UUID subscriptionId,
+      UUID userId,
+      UUID interestId,
+      String interestName,
+      List<String> interestKeywords,
+      long interestSubscriberCount,
+      Instant createdAt
+  );
 
+  void onUnsubscribed(UUID subscriptionId);
+  void onUnsubscribed(UUID userId, UUID interestId);
+
+  // ===== 댓글 =====
+  void onCommentCreated(
+      UUID commentId,
+      UUID userId,
+      UUID articleId,
+      String articleTitle,
+      String commentUserNickname,
+      String content,
+      long likeCount,
+      Instant createdAt
+  );
+
+  void onCommentDeleted(UUID commentId);
+  void onCommentDeleted(UUID commentId, Instant deletedAt);
+
+  // ===== 댓글 좋아요 =====
+  void onCommentLiked(
+      UUID likeEventId,
+      UUID userId,                // likedBy
+      UUID commentId,
+      UUID articleId,
+      String articleTitle,
+      UUID commentUserId,
+      String commentUserNickname,
+      String commentContent,
+      long commentLikeCount,
+      Instant commentCreatedAt,
+      Instant likeCreatedAt
+  );
+
+  // 호환용 1-파라미터 → 2-파라미터로 위임
+  default void onCommentLikeCanceled(UUID likeEventId) {
+    onCommentLikeCanceled(likeEventId, null);
+  }
+
+  // 실제 구현해야 할 시그니처(필요시 userId 전달)
+  void onCommentLikeCanceled(UUID likeEventId, UUID userId);
 }

--- a/monew/src/main/java/com/spring/monew/activity/repository/UserActivityQueryRepository.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/UserActivityQueryRepository.java
@@ -1,5 +1,25 @@
 package com.spring.monew.activity.repository;
 
+import com.spring.monew.activity.controller.dto.response.UserActivityDto;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+//활동 내역 조회 전용 리포지토리(읽기 모델).
+
 public interface UserActivityQueryRepository {
 
+  // RDB에서 사용자 요약 정보만 조회
+  record UserSummary(UUID id, String email, String nickname, Instant createdAt) {}
+
+  Optional<UserSummary> findUserSummary(UUID userId);
+
+  List<UserActivityDto.Subscription> findTopSubscriptions(UUID userId, int topN);
+
+  List<UserActivityDto.Comment> findTopComments(UUID userId, int topN);
+
+  List<UserActivityDto.CommentLike> findTopCommentLikes(UUID userId, int topN);
+
+  List<UserActivityDto.ArticleView> findTopArticleViews(UUID userId, int topN);
 }

--- a/monew/src/main/java/com/spring/monew/activity/repository/impl/ActivitySyncRepositoryImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/impl/ActivitySyncRepositoryImpl.java
@@ -80,6 +80,7 @@ public class ActivitySyncRepositoryImpl implements ActivitySyncRepository {
             .set("userId", userId)
             .set("articleId", articleId)
             .set("articleTitle", articleTitle)
+            .set("commentUserNickname", commentUserNickname)
             .set("content", content)
             .set("likeCount", likeCount)
             .set("createdAt", createdAt);

--- a/monew/src/main/java/com/spring/monew/activity/repository/impl/ActivitySyncRepositoryImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/impl/ActivitySyncRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.spring.monew.activity.repository.impl;
 
 import com.mongodb.client.result.UpdateResult;
-import com.spring.monew.activity.domain.ActivityArticleViewDoc;
 import com.spring.monew.activity.domain.ActivityCommentDoc;
 import com.spring.monew.activity.domain.ActivityCommentLikeDoc;
 import com.spring.monew.activity.domain.UserInterestSubscriptionDoc;
@@ -24,4 +23,150 @@ public class ActivitySyncRepositoryImpl implements ActivitySyncRepository {
 
     private final MongoTemplate mongo;
 
+    // ====== 구독 ======
+    @Override
+    public void onSubscribed(UUID subscriptionId, UUID userId, UUID interestId, String interestName,
+        List<String> interestKeywords, long interestSubscriberCount, Instant createdAt) {
+        if (subscriptionId == null || userId == null || interestId == null) {
+            log.warn("onSubscribed skipped: subscriptionId={}, userId={}, interestId={}", subscriptionId, userId, interestId);
+            return;
+        }
+        Update up = new Update()
+            .set("user_id", userId)
+            .set("interest_id", interestId)
+            .set("interest_name", interestName)
+            .set("interest_keywords", interestKeywords)
+            .set("interest_subscriber_count", interestSubscriberCount)
+            .set("created_at", createdAt);
+
+        UpdateResult r = mongo.upsert(
+            Query.query(Criteria.where("_id").is(subscriptionId.toString())),
+            up, UserInterestSubscriptionDoc.class
+        );
+        log.info("onSubscribed -> matched={}, modified={}, upsertedId={}", r.getMatchedCount(), r.getModifiedCount(), r.getUpsertedId());
+
+        if (r.getMatchedCount() == 0 && r.getUpsertedId() == null) {
+            Query legacyKey = Query.query(
+                Criteria.where("user_id").in(userId, userId.toString())
+                    .and("interest_id").in(interestId, interestId.toString())
+            );
+            up.setOnInsert("_id", subscriptionId.toString());
+            UpdateResult r2 = mongo.upsert(legacyKey, up, UserInterestSubscriptionDoc.class);
+            log.info("onSubscribed[legacy-fallback] -> matched={}, modified={}, upsertedId={}",
+                r2.getMatchedCount(), r2.getModifiedCount(), r2.getUpsertedId());
+        }
+    }
+
+    @Override
+    public void onUnsubscribed(UUID subscriptionId) {
+        mongo.remove(Query.query(Criteria.where("_id").is(subscriptionId.toString())),
+            UserInterestSubscriptionDoc.class);
+    }
+
+    @Override
+    public void onUnsubscribed(UUID userId, UUID interestId) {
+        Query q = Query.query(
+            Criteria.where("user_id").in(userId, userId.toString())
+                .and("interest_id").in(interestId, interestId.toString())
+        );
+        mongo.remove(q, UserInterestSubscriptionDoc.class);
+    }
+
+    // ====== 댓글 ======
+    @Override
+    public void onCommentCreated(UUID commentId, UUID userId, UUID articleId, String articleTitle,
+        String commentUserNickname, String content, long likeCount, Instant createdAt) {
+        Update up = new Update()
+            .set("userId", userId)
+            .set("articleId", articleId)
+            .set("articleTitle", articleTitle)
+            .set("content", content)
+            .set("likeCount", likeCount)
+            .set("createdAt", createdAt);
+
+        mongo.upsert(
+            Query.query(Criteria.where("_id").is(commentId.toString())),
+            up,
+            ActivityCommentDoc.class
+        );
+    }
+
+    @Override
+    public void onCommentDeleted(UUID commentId) {
+        mongo.remove(
+            Query.query(Criteria.where("_id").is(commentId.toString())),
+            ActivityCommentDoc.class
+        );
+    }
+
+    @Override
+    public void onCommentDeleted(UUID commentId, Instant deletedAt) {
+        onCommentDeleted(commentId); // deletedAt은 현재 미사용
+    }
+
+    // ====== 댓글 좋아요 ======
+    @Override
+    public void onCommentLiked(UUID likeEventId, UUID userId, UUID commentId, UUID articleId, String articleTitle,
+        UUID commentUserId, String commentUserNickname, String commentContent,
+        long commentLikeCount, Instant commentCreatedAt, Instant likeCreatedAt) {
+
+        // 1) 좋아요 이벤트 upsert
+        Update up = new Update()
+            .set("userId", userId) // likedBy
+            .set("commentId", commentId)
+            .set("articleId", articleId)
+            .set("articleTitle", articleTitle)
+            .set("commentUserId", commentUserId)
+            .set("commentUserNickname", commentUserNickname)
+            .set("commentContent", commentContent)
+            .set("commentLikeCount", commentLikeCount)
+            .set("commentCreatedAt", commentCreatedAt)
+            .set("createdAt", likeCreatedAt);
+
+        mongo.upsert(
+            Query.query(Criteria.where("_id").is(likeEventId.toString())),
+            up,
+            ActivityCommentLikeDoc.class
+        );
+
+        // 2) 댓글 스냅샷의 likeCount 를 정답 스냅샷 값으로 동기화
+        Query q = Query.query(Criteria.where("_id").is(commentId.toString()));
+        Update sync = new Update()
+            .set("likeCount", commentLikeCount)
+            .set("lastLikedAt", likeCreatedAt);
+        mongo.updateFirst(q, sync, ActivityCommentDoc.class);
+    }
+
+    @Override
+    public void onCommentLikeCanceled(UUID likeId, UUID userId) {
+        // 1) 어떤 댓글의 좋아요인지 먼저 조회
+        ActivityCommentLikeDoc likeDoc =
+            mongo.findById(likeId.toString(), ActivityCommentLikeDoc.class);
+
+        // 2) like 문서 삭제
+        mongo.remove(
+            Query.query(Criteria.where("_id").is(likeId.toString())),
+            ActivityCommentLikeDoc.class
+        );
+
+        // 3) 댓글 스냅샷의 likeCount 감소 (하한 0 보정)
+        if (likeDoc != null && likeDoc.getCommentId() != null) {
+            String commentKey = likeDoc.getCommentId().toString();
+
+            // 3-1) 우선 1 감소
+            Query q = Query.query(Criteria.where("_id").is(commentKey));
+            Update dec = new Update().inc("likeCount", -1);
+            mongo.updateFirst(q, dec, ActivityCommentDoc.class);
+
+            // 3-2) 음수 방지
+            Query fixNeg = Query.query(
+                new Criteria().andOperator(
+                    Criteria.where("_id").is(commentKey),
+                    Criteria.where("likeCount").lt(0)
+                )
+            );
+            Update zero = new Update().set("likeCount", 0);
+            mongo.updateFirst(fixNeg, zero, ActivityCommentDoc.class);
+        }
+    }
 }

--- a/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
@@ -30,4 +30,118 @@ public class UserActivityQueryRepositoryImpl implements UserActivityQueryReposit
 
     private final MongoTemplate mongo;
     private final JdbcTemplate jdbc;
+
+    @Override
+    public Optional<UserSummary> findUserSummary(UUID userId) {
+        try {
+            return Optional.ofNullable(
+                jdbc.queryForObject(
+                    "SELECT id, email, nickname, created_at FROM users WHERE id = ?",
+                    (rs, rowNum) -> new UserSummary(
+                        uuid(rs, "id"), rs.getString("email"), rs.getString("nickname"),
+                        rs.getTimestamp("created_at") != null
+                            ? rs.getTimestamp("created_at").toInstant()
+                            : Instant.now()
+                    ),
+                    userId
+                )
+            );
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<UserActivityDto.Subscription> findTopSubscriptions(UUID userId, int topN) {
+        Query q = new Query();
+        q.addCriteria(Criteria.where("userId").is(userId));
+        q.with(Sort.by(desc("createdAt"), desc("_id")));
+        q.limit(topN);
+        List<UserInterestSubscriptionDoc> docs = mongo.find(q, UserInterestSubscriptionDoc.class);
+        List<UserActivityDto.Subscription> out = new ArrayList<UserActivityDto.Subscription>(
+            docs.size());
+        for (UserInterestSubscriptionDoc d : docs) {
+            out.add(new UserActivityDto.Subscription(
+                UUID.fromString(d.getId()), d.getInterestId(), d.getInterestName(),
+                d.getInterestKeywords(), d.getInterestSubscriberCount(), d.getCreatedAt()
+            ));
+        }
+        return out;
+    }
+
+    @Override
+    public List<UserActivityDto.Comment> findTopComments(UUID userId, int topN) {
+        Query q = new Query();
+        q.addCriteria(Criteria.where("userId").is(userId));
+        q.with(Sort.by(desc("createdAt"), desc("_id")));
+        q.limit(topN);
+        List<ActivityCommentDoc> docs = mongo.find(q, ActivityCommentDoc.class);
+        List<UserActivityDto.Comment> out = new ArrayList<UserActivityDto.Comment>(docs.size());
+        for (ActivityCommentDoc d : docs) {
+            out.add(new UserActivityDto.Comment(
+                UUID.fromString(d.getId()), d.getArticleId(), d.getArticleTitle(),
+                d.getUserId(), null, d.getContent(), d.getLikeCount(), d.getCreatedAt()
+            ));
+        }
+        return out;
+    }
+
+    @Override
+    public List<UserActivityDto.CommentLike> findTopCommentLikes(UUID userId, int topN) {
+        Query q = new Query();
+        q.addCriteria(Criteria.where("userId").is(userId));
+        q.with(Sort.by(desc("createdAt"), desc("_id")));
+        q.limit(topN);
+        List<ActivityCommentLikeDoc> docs = mongo.find(q, ActivityCommentLikeDoc.class);
+        List<UserActivityDto.CommentLike> out = new ArrayList<UserActivityDto.CommentLike>(
+            docs.size());
+        for (ActivityCommentLikeDoc d : docs) {
+            out.add(new UserActivityDto.CommentLike(
+                UUID.fromString(d.getId()), d.getCreatedAt(), d.getCommentId(), d.getArticleId(),
+                d.getArticleTitle(),
+                d.getCommentUserId(), d.getCommentUserNickname(), d.getCommentContent(),
+                d.getCommentLikeCount(), d.getCommentCreatedAt()
+            ));
+        }
+        return out;
+    }
+
+    // article views
+    @Override
+    public List<UserActivityDto.ArticleView> findTopArticleViews(UUID userId, int topN) {
+        Query q = new Query();
+        q.addCriteria(Criteria.where("userId").is(userId));
+        q.with(Sort.by(desc("lastViewedAt"), desc("_id")));
+        q.limit(topN);
+
+        List<ActivityArticleViewDoc> docs = mongo.find(q, ActivityArticleViewDoc.class);
+        List<UserActivityDto.ArticleView> out = new ArrayList<>(docs.size());
+
+        for (ActivityArticleViewDoc d : docs) {
+            long cc = d.getCommentCount() == null ? 0L : d.getCommentCount();
+            long vc = d.getViewCount()    == null ? 0L : d.getViewCount();
+
+            out.add(new UserActivityDto.ArticleView(
+                UUID.fromString(d.getId()),
+                d.getUserId(),
+                d.getCreatedAt(),      // 필요시 d.getLastViewedAt()로 교체 가능
+                d.getArticleId(),
+                d.getSource(),
+                d.getSourceUrl(),
+                d.getTitle(),
+                d.getPublishDate(),
+                d.getSummary(),
+                cc,
+                vc
+            ));
+        }
+        return out;
+    }
+
+    // === 클래스 레벨(아래처럼 메서드 밖) ===
+    private static UUID uuid(ResultSet rs, String col) throws SQLException {
+        Object obj = rs.getObject(col);
+        if (obj instanceof UUID u) return u;      // 자바 17 패턴 매칭
+        return UUID.fromString(Objects.toString(obj));
+    }
 }

--- a/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
@@ -39,9 +39,7 @@ public class UserActivityQueryRepositoryImpl implements UserActivityQueryReposit
                     "SELECT id, email, nickname, created_at FROM users WHERE id = ?",
                     (rs, rowNum) -> new UserSummary(
                         uuid(rs, "id"), rs.getString("email"), rs.getString("nickname"),
-                        rs.getTimestamp("created_at") != null
-                            ? rs.getTimestamp("created_at").toInstant()
-                            : Instant.now()
+                        rs.getTimestamp("created_at").toInstant()  // NPE 발생 시 데이터 문제로 간주
                     ),
                     userId
                 )
@@ -155,7 +153,7 @@ public class UserActivityQueryRepositoryImpl implements UserActivityQueryReposit
             out.add(new UserActivityDto.ArticleView(
                 UUID.fromString(d.getId()),
                 d.getUserId(),
-                d.getCreatedAt(),      // 필요시 d.getLastViewedAt()로 교체 가능
+                d.getLastViewedAt(),   // 최근 조회 시각     // 필요시 d.getLastViewedAt()로 교체 가능
                 d.getArticleId(),
                 d.getSource(),
                 d.getSourceUrl(),

--- a/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
@@ -75,15 +75,46 @@ public class UserActivityQueryRepositoryImpl implements UserActivityQueryReposit
         q.addCriteria(Criteria.where("userId").is(userId));
         q.with(Sort.by(desc("createdAt"), desc("_id")));
         q.limit(topN);
+
         List<ActivityCommentDoc> docs = mongo.find(q, ActivityCommentDoc.class);
-        List<UserActivityDto.Comment> out = new ArrayList<UserActivityDto.Comment>(docs.size());
+        List<UserActivityDto.Comment> out = new ArrayList<>(docs.size());
+
         for (ActivityCommentDoc d : docs) {
+            // ① 스냅샷에서 우선 가져온다
+            String nickname = d.getUserNickname();
+
+            // ② 과거 스냅샷(닉네임 비어 있음) 폴백: RDB에서 한 번 더 조회
+            if (nickname == null || nickname.isBlank()) {
+                nickname = findNicknameFallback(d.getUserId());
+                if (nickname == null || nickname.isBlank()) {
+                    nickname = "(알 수 없음)";
+                }
+            }
             out.add(new UserActivityDto.Comment(
-                UUID.fromString(d.getId()), d.getArticleId(), d.getArticleTitle(),
-                d.getUserId(), null, d.getContent(), d.getLikeCount(), d.getCreatedAt()
+                UUID.fromString(d.getId()),
+                d.getArticleId(),
+                d.getArticleTitle(),
+                d.getUserId(),
+                nickname,
+                d.getContent(),
+                d.getLikeCount(),
+                d.getCreatedAt()
             ));
         }
         return out;
+    }
+
+    private String findNicknameFallback(UUID userId) {
+        try {
+            // users 테이블에 nickname 컬럼 있는 전제
+            return jdbc.queryForObject(
+                "SELECT nickname FROM users WHERE id = ?",
+                String.class,
+                userId
+            );
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
     }
 
     @Override

--- a/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
@@ -153,7 +153,7 @@ public class UserActivityQueryRepositoryImpl implements UserActivityQueryReposit
             out.add(new UserActivityDto.ArticleView(
                 UUID.fromString(d.getId()),
                 d.getUserId(),
-                d.getLastViewedAt(),   // 최근 조회 시각     // 필요시 d.getLastViewedAt()로 교체 가능
+                d.getLastViewedAt(),   // 최근 조회 시각
                 d.getArticleId(),
                 d.getSource(),
                 d.getSourceUrl(),

--- a/monew/src/main/java/com/spring/monew/activity/service/UserActivityService.java
+++ b/monew/src/main/java/com/spring/monew/activity/service/UserActivityService.java
@@ -1,0 +1,8 @@
+package com.spring.monew.activity.service;
+
+import com.spring.monew.activity.controller.dto.response.UserActivityDto;
+import java.util.UUID;
+
+public interface UserActivityService {
+  UserActivityDto getUserActivity(UUID userId);
+}

--- a/monew/src/main/java/com/spring/monew/activity/service/impl/UserActivityServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/service/impl/UserActivityServiceImpl.java
@@ -1,0 +1,36 @@
+package com.spring.monew.activity.service.impl;
+
+import com.spring.monew.activity.controller.dto.response.UserActivityDto;
+import com.spring.monew.activity.repository.UserActivityQueryRepository;
+import com.spring.monew.activity.repository.UserActivityQueryRepository.UserSummary;
+import com.spring.monew.activity.service.UserActivityService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserActivityServiceImpl implements UserActivityService {
+
+  private static final int TOP_N = 10;
+  private final UserActivityQueryRepository repo;
+
+  @Override
+  @Transactional(readOnly = true)
+  public UserActivityDto getUserActivity(UUID userId) {
+    UserSummary u = repo.findUserSummary(userId)
+        .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+    List<UserActivityDto.Subscription> subs = repo.findTopSubscriptions(userId, TOP_N);
+    List<UserActivityDto.Comment> comments = repo.findTopComments(userId, TOP_N);
+    List<UserActivityDto.CommentLike> likes = repo.findTopCommentLikes(userId, TOP_N);
+    List<UserActivityDto.ArticleView> views = repo.findTopArticleViews(userId, TOP_N);
+
+    return new UserActivityDto(
+        u.id(), u.email(), u.nickname(), u.createdAt(),
+        subs, comments, likes, views
+    );
+  }
+}

--- a/monew/src/main/java/com/spring/monew/article/domain/Article.java
+++ b/monew/src/main/java/com/spring/monew/article/domain/Article.java
@@ -27,6 +27,9 @@ public class Article {
     @JoinColumn(name = "interest_id", nullable = false)
     private Interest interest;
 
+    @Column(name = "interest_id", insertable = false, updatable = false)
+    private UUID interestId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "source", nullable = false)
     private ArticleSource source;

--- a/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
+++ b/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
@@ -1,9 +1,16 @@
 package com.spring.monew.article.repository;
 
 import com.spring.monew.article.domain.Article;
+import java.util.Collection;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ArticleRepository extends JpaRepository<Article, UUID>, ArticleRepositoryCustom {
-                boolean existsBySourceUrl(String sourceUrl);
+  boolean existsBySourceUrl(String sourceUrl);
+
+  @Query("select a.sourceUrl from Article a where a.sourceUrl in :urls")
+  Set<String> findExistingSourceUrls(@Param("urls") Collection<String> urls);
 }

--- a/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
+++ b/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
@@ -5,4 +5,5 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleRepository extends JpaRepository<Article, UUID>, ArticleRepositoryCustom {
+                boolean existsBySourceUrl(String sourceUrl);
 }

--- a/monew/src/main/java/com/spring/monew/batch/config/NewsCollectionJobConfig.java
+++ b/monew/src/main/java/com/spring/monew/batch/config/NewsCollectionJobConfig.java
@@ -5,6 +5,8 @@ import com.spring.monew.batch.reader.ArticleCandidateReader;
 import com.spring.monew.batch.writer.ArticleWriter;
 import com.spring.monew.article.client.dto.ArticleCandidate;
 import com.spring.monew.article.domain.Article;
+import com.spring.monew.batch.listener.ArticleNotificationListener;
+import org.springframework.batch.core.ItemWriteListener;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -26,6 +28,7 @@ public class NewsCollectionJobConfig {
     private final ArticleCandidateProcessor articleCandidateProcessor;
     private final ArticleWriter articleWriter;
     private final BatchSkipListener batchSkipListener;
+    private final ArticleNotificationListener articleNotificationListener;
 
     @Bean
     public Job newsCollectionJob() {
@@ -44,6 +47,8 @@ public class NewsCollectionJobConfig {
                 .listener(articleCandidateReader)
                 .listener(articleCandidateProcessor)
                 .listener(batchSkipListener)
+                .listener((ItemWriteListener<? super Article>) articleNotificationListener)
+                .listener((org.springframework.batch.core.StepExecutionListener) articleNotificationListener)
                 .faultTolerant()
                 .skip(DataIntegrityViolationException.class)
                 .skipLimit(100)

--- a/monew/src/main/java/com/spring/monew/batch/config/NewsCollectionJobConfig.java
+++ b/monew/src/main/java/com/spring/monew/batch/config/NewsCollectionJobConfig.java
@@ -47,7 +47,7 @@ public class NewsCollectionJobConfig {
                 .listener(articleCandidateReader)
                 .listener(articleCandidateProcessor)
                 .listener(batchSkipListener)
-                .listener((ItemWriteListener<? super Article>) articleNotificationListener)
+                .listener((org.springframework.batch.core.ItemWriteListener<? super Article>) articleNotificationListener)
                 .listener((org.springframework.batch.core.StepExecutionListener) articleNotificationListener)
                 .faultTolerant()
                 .skip(DataIntegrityViolationException.class)

--- a/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
+++ b/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
@@ -92,7 +92,7 @@ public class ArticleNotificationListener extends ItemListenerSupport<Article, Ar
       // FK 필드 직접 접근 우선 (lazy loading 회피)
       try {
         interestId = a.getInterestId();
-        } catch (Exception ignore) { /* 안전장치 */ }
+      } catch (Exception ignore) { /* 안전장치 */ }
       if (interestId == null && a.getInterest() != null) {
         interestId = a.getInterest().getId();
       }

--- a/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
+++ b/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
@@ -6,16 +6,21 @@ import com.spring.monew.interest.repository.InterestRepository;
 import com.spring.monew.notification.domain.NotificationResourceType;
 import com.spring.monew.notification.service.NotificationService;
 import com.spring.monew.subscription.repository.SubscriptionRepository;
+import java.io.Serializable;
 import java.util.*;
+import java.util.stream.Collectors;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.batch.core.listener.ItemListenerSupport;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.batch.item.Chunk;
-import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -23,80 +28,159 @@ import org.springframework.stereotype.Component;
 public class ArticleNotificationListener extends ItemListenerSupport<Article, Article>
     implements StepExecutionListener {
 
-  private final SubscriptionRepository subscriptionRepository;
-  private final InterestRepository interestRepository;
-  private final NotificationService notificationService;
+  private static final String COUNT_MAP_KEY = "aggByInterest";
 
-  // interestId 별 기사 건수 집계 (afterWrite에서 id만 사용: LAZY 안전)
-  private final Map<UUID, Integer> countByInterest = new HashMap<>();
+  private final SubscriptionRepository subscriptionRepository;
+  private final NotificationService notificationService;
+  private final InterestRepository interestRepository; // ★ 이름 벌크 조회용
+
+  // EC에 저장될 집계 구조
+  public static final class Agg implements Serializable {
+    public int count;
+    public String interestName; // afterStep에서 채움
+    public Agg() {}
+    public Agg(int count) { this.count = count; }
+  }
 
   @Override
   public void beforeStep(@NonNull StepExecution stepExecution) {
-    countByInterest.clear();
+    stepExecution.getExecutionContext().put(COUNT_MAP_KEY, new HashMap<UUID, Agg>());
   }
 
-  // Writer 커밋 후 호출 — 지연 로딩 접근 금지(식별자만)
+  @SuppressWarnings("unchecked")
+  private Map<UUID, Agg> getAggMap() {
+    return (Map<UUID, Agg>) StepSynchronizationManager.getContext()
+        .getStepExecution().getExecutionContext()
+        .get(COUNT_MAP_KEY);
+  }
+
   @Override
-  public void afterWrite(Chunk<? extends Article> items) {
-    for (Article a : items) {
-      UUID interestId = (a.getInterest() != null) ? a.getInterest().getId() : null;
-      if (interestId == null) continue;
-      countByInterest.merge(interestId, 1, Integer::sum);
+  public void afterWrite(@NonNull Chunk<? extends Article> items) {
+    Map<UUID, Agg> map = getAggMap();
+    if (map == null) {
+      log.warn("[알림] 집계 맵 누락 - 스킵");
+      return;
     }
+
+    int candidates = 0, counted = 0;
+    for (Article a : items) {
+      if (a == null) continue;
+      candidates++;
+
+      // 핵심: 연관 ID 우선, 없으면 읽기전용 FK 보조
+      UUID interestId = null;
+      if (a.getInterest() != null) {
+        // Hibernate 프록시여도 getId()는 초기화 없이 안전
+        interestId = a.getInterest().getId();
+      }
+      if (interestId == null) {
+        interestId = a.getInterestId();
+      }
+      if (interestId == null) continue; // 집계 불가
+
+      map.compute(interestId, (k, v) -> {
+        if (v == null) return new Agg(1);
+        v.count += 1;
+        return v;
+      });
+      counted++;
+    }
+    log.debug("[알림] afterWrite 집계: 후보 {}건 중 {}건 카운팅", candidates, counted);
   }
 
-  // 스텝 종료 시 한 번만 알림 발송
   @Override
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public ExitStatus afterStep(@NonNull StepExecution stepExecution) {
-    if (countByInterest.isEmpty()) {
+    // Writer가 EC에 Map<UUID,Integer> 형태로 누적해 둔 경우를 흡수/정규화
+    Object raw = stepExecution.getExecutionContext().get(COUNT_MAP_KEY);
+    Map<UUID, Agg> map;
+
+    if (raw == null) {
+      log.debug("[알림] 이번 스텝에서 집계 없음(EC 비어있음)");
       return stepExecution.getExitStatus();
     }
 
-    // 1) 관심사 이름 일괄 조회(N+1 방지)
-    List<UUID> interestIds = new ArrayList<>(countByInterest.keySet());
-    Map<UUID, String> nameByInterest = new HashMap<>();
-    for (Interest it : interestRepository.findAllById(interestIds)) {
-      nameByInterest.put(it.getId(), it.getName());
+    if (raw instanceof Map<?, ?> anyMap) {
+      if (anyMap.isEmpty()) {
+        // 비어 있어도 타입을 Agg로 확정해 둠
+        map = new HashMap<>();
+        stepExecution.getExecutionContext().put(COUNT_MAP_KEY, map);
+      } else {
+        Object sampleVal = anyMap.values().iterator().next();
+        if (sampleVal instanceof Agg) {
+          // 이미 리스너 집계(Map<UUID, Agg>) 형태
+          @SuppressWarnings("unchecked")
+          Map<UUID, Agg> casted = (Map<UUID, Agg>) anyMap;
+          map = casted;
+        } else if (sampleVal instanceof Integer) {
+          // Writer 집계(Map<UUID, Integer>)를 Agg로 변환하여 대체
+          Map<UUID, Agg> converted = new HashMap<>();
+          for (Map.Entry<?, ?> e : anyMap.entrySet()) {
+            Object k = e.getKey();
+            Object v = e.getValue();
+            if (k instanceof UUID key && v instanceof Integer cnt) {
+              converted.put(key, new Agg(cnt));
+            }
+          }
+          // EC에 Agg 맵으로 치환
+          stepExecution.getExecutionContext().put(COUNT_MAP_KEY, converted);
+          map = converted;
+          log.debug("[알림] Writer 집계를 Agg로 정규화: {}개", map.size());
+        } else {
+          log.warn("[알림] 지원하지 않는 집계 타입: {}", sampleVal.getClass().getName());
+          return stepExecution.getExitStatus();
+        }
+      }
+    } else {
+      log.warn("[알림] EC '{}' 값이 Map이 아님: {}", COUNT_MAP_KEY, raw.getClass().getName());
+      return stepExecution.getExitStatus();
     }
 
-    int topicSent = 0;
-    int topicFailed = 0;
+    if (map.isEmpty()) {
+      log.debug("[알림] 이번 스텝에서 집계 없음");
+      return stepExecution.getExitStatus();
+    }
 
-    // 2) 관심사별 구독자 조회 → 알림 발송 (실패는 로그만, 배치 실패로 전파하지 않음)
-    for (UUID interestId : interestIds) {
-      int cnt = countByInterest.getOrDefault(interestId, 0);
-      if (cnt <= 0) continue;
+    // 관심사 이름 벌크 로딩(지연로딩 금지, 한 번에)
+    Set<UUID> interestIds = map.keySet();
+    Map<UUID, String> names = interestRepository.findAllById(interestIds).stream()
+        .collect(Collectors.toMap(Interest::getId, it -> {
+          String name = it.getName();
+          return (name == null || name.isBlank()) ? "관심사" : name;
+        }));
 
-      List<UUID> subscriberIds = subscriptionRepository.findUserIdsByInterestId(interestId);
-      if (subscriberIds == null || subscriberIds.isEmpty()) continue;
+    int kinds = map.size();
+    int sentBatches = 0;
 
-      String interestName = nameByInterest.getOrDefault(interestId, "관심사");
-      String content = interestName + "와 관련된 기사가 " + cnt + "건 등록되었습니다.";
+    for (Map.Entry<UUID, Agg> e : map.entrySet()) {
+      UUID interestId = e.getKey();
+      Agg agg = e.getValue();
+      agg.interestName = names.getOrDefault(interestId, "관심사");
 
       try {
+        List<UUID> subscriberIds = subscriptionRepository.findUserIdsByInterestId(interestId);
+        if (subscriberIds == null || subscriberIds.isEmpty()) {
+          log.debug("[알림] 구독자 없음: interestId={}", interestId);
+          continue;
+        }
+
+        String content = String.format("%s와 관련된 기사가 %d건 등록되었습니다.",
+            agg.interestName, agg.count);
+
         notificationService.createForUsers(
             subscriberIds,
             content,
-            NotificationResourceType.SUBSCRIPTION, // FE 직렬화: "interest"
+            NotificationResourceType.SUBSCRIPTION,
             interestId
         );
-        topicSent++;
-      } catch (Exception e) {
-        topicFailed++;
-        log.error(
-            "[ArticleNotificationListener] Failed to send notification: interestId={}, interestName={}, count={}, subscribers={}",
-            interestId, interestName, cnt, subscriberIds.size(), e
-        );
-        // 부가 기능 실패이므로 배치 스텝은 실패 처리하지 않음
+        sentBatches++;
+      } catch (Exception ex) {
+        log.warn("[알림] 관심사 알림 생성 실패: interestId={}, name={}, count={}",
+            interestId, agg.interestName, agg.count, ex);
       }
     }
 
-    log.info(
-        "[ArticleNotificationListener] notification topics sent={}, failed={}, interests={}",
-        topicSent, topicFailed, countByInterest.size()
-    );
-
-    countByInterest.clear();
+    log.info("[알림] 관심사별 배치 알림 생성 완료: 관심사 종류 {}개, 발송 {}건", kinds, sentBatches);
     return stepExecution.getExitStatus();
   }
 }

--- a/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
+++ b/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
@@ -1,0 +1,102 @@
+package com.spring.monew.batch.listener;
+
+import com.spring.monew.article.domain.Article;
+import com.spring.monew.interest.domain.Interest;
+import com.spring.monew.interest.repository.InterestRepository;
+import com.spring.monew.notification.domain.NotificationResourceType;
+import com.spring.monew.notification.service.NotificationService;
+import com.spring.monew.subscription.repository.SubscriptionRepository;
+import java.util.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.listener.ItemListenerSupport;
+import org.springframework.batch.item.Chunk;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ArticleNotificationListener extends ItemListenerSupport<Article, Article>
+    implements StepExecutionListener {
+
+  private final SubscriptionRepository subscriptionRepository;
+  private final InterestRepository interestRepository;
+  private final NotificationService notificationService;
+
+  // interestId 별 기사 건수 집계 (afterWrite에서 id만 사용: LAZY 안전)
+  private final Map<UUID, Integer> countByInterest = new HashMap<>();
+
+  @Override
+  public void beforeStep(@NonNull StepExecution stepExecution) {
+    countByInterest.clear();
+  }
+
+  // Writer 커밋 후 호출 — 지연 로딩 접근 금지(식별자만)
+  @Override
+  public void afterWrite(Chunk<? extends Article> items) {
+    for (Article a : items) {
+      UUID interestId = (a.getInterest() != null) ? a.getInterest().getId() : null;
+      if (interestId == null) continue;
+      countByInterest.merge(interestId, 1, Integer::sum);
+    }
+  }
+
+  // 스텝 종료 시 한 번만 알림 발송
+  @Override
+  public ExitStatus afterStep(@NonNull StepExecution stepExecution) {
+    if (countByInterest.isEmpty()) {
+      return stepExecution.getExitStatus();
+    }
+
+    // 1) 관심사 이름 일괄 조회(N+1 방지)
+    List<UUID> interestIds = new ArrayList<>(countByInterest.keySet());
+    Map<UUID, String> nameByInterest = new HashMap<>();
+    for (Interest it : interestRepository.findAllById(interestIds)) {
+      nameByInterest.put(it.getId(), it.getName());
+    }
+
+    int topicSent = 0;
+    int topicFailed = 0;
+
+    // 2) 관심사별 구독자 조회 → 알림 발송 (실패는 로그만, 배치 실패로 전파하지 않음)
+    for (UUID interestId : interestIds) {
+      int cnt = countByInterest.getOrDefault(interestId, 0);
+      if (cnt <= 0) continue;
+
+      List<UUID> subscriberIds = subscriptionRepository.findUserIdsByInterestId(interestId);
+      if (subscriberIds == null || subscriberIds.isEmpty()) continue;
+
+      String interestName = nameByInterest.getOrDefault(interestId, "관심사");
+      String content = interestName + "와 관련된 기사가 " + cnt + "건 등록되었습니다.";
+
+      try {
+        notificationService.createForUsers(
+            subscriberIds,
+            content,
+            NotificationResourceType.SUBSCRIPTION, // FE 직렬화: "interest"
+            interestId
+        );
+        topicSent++;
+      } catch (Exception e) {
+        topicFailed++;
+        log.error(
+            "[ArticleNotificationListener] Failed to send notification: interestId={}, interestName={}, count={}, subscribers={}",
+            interestId, interestName, cnt, subscriberIds.size(), e
+        );
+        // 부가 기능 실패이므로 배치 스텝은 실패 처리하지 않음
+      }
+    }
+
+    log.info(
+        "[ArticleNotificationListener] notification topics sent={}, failed={}, interests={}",
+        topicSent, topicFailed, countByInterest.size()
+    );
+
+    countByInterest.clear();
+    return stepExecution.getExitStatus();
+  }
+}

--- a/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
+++ b/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
@@ -9,6 +9,9 @@ import com.spring.monew.subscription.repository.SubscriptionRepository;
 import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,13 +42,16 @@ public class ArticleNotificationListener extends ItemListenerSupport<Article, Ar
   private boolean optimize; // 설정 주입
 
   // EC에 저장될 집계 구조
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static final class Agg implements Serializable {
-    public String interestName;
-    public int count;
-    public Agg() {}
-    public Agg(int count) { this.count = count; }
+    private String interestName;
+    private int count;
+    public Agg(int count) {
+           this.count = count;
+    }
   }
-
   @Override
   public void beforeStep(@NonNull StepExecution stepExecution) {
     // 최적화 모드라도 listener가 필요시 쓸 수 있도록 키만 초기화(타입은 afterWrite/afterStep에서 보장)

--- a/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
+++ b/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
@@ -18,6 +18,7 @@ import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.batch.core.listener.ItemListenerSupport;
 import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.batch.item.Chunk;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,51 +33,69 @@ public class ArticleNotificationListener extends ItemListenerSupport<Article, Ar
 
   private final SubscriptionRepository subscriptionRepository;
   private final NotificationService notificationService;
-  private final InterestRepository interestRepository; // ★ 이름 벌크 조회용
+  private final InterestRepository interestRepository;
+
+  @Value("${monew.writer.optimize:false}")
+  private boolean optimize; // 설정 주입
 
   // EC에 저장될 집계 구조
   public static final class Agg implements Serializable {
+    public String interestName;
     public int count;
-    public String interestName; // afterStep에서 채움
     public Agg() {}
     public Agg(int count) { this.count = count; }
   }
 
   @Override
   public void beforeStep(@NonNull StepExecution stepExecution) {
-    stepExecution.getExecutionContext().put(COUNT_MAP_KEY, new HashMap<UUID, Agg>());
+    // 최적화 모드라도 listener가 필요시 쓸 수 있도록 키만 초기화(타입은 afterWrite/afterStep에서 보장)
+    if (!stepExecution.getExecutionContext().containsKey(COUNT_MAP_KEY)) {
+      stepExecution.getExecutionContext().put(COUNT_MAP_KEY, new HashMap<>());
+    }
   }
 
   @SuppressWarnings("unchecked")
-  private Map<UUID, Agg> getAggMap() {
-    return (Map<UUID, Agg>) StepSynchronizationManager.getContext()
-        .getStepExecution().getExecutionContext()
-        .get(COUNT_MAP_KEY);
+  private Map<UUID, Agg> getOrInitAggMap() {
+    var ec = StepSynchronizationManager.getContext().getStepExecution().getExecutionContext();
+    Object obj = ec.get(COUNT_MAP_KEY);
+
+    // writer 최적화 모드면 afterWrite는 스킵하므로 여기서 Map<UUID, Agg>를 사용할 일은 거의 없음
+    if (obj instanceof Map) {
+      try {
+        return (Map<UUID, Agg>) obj; // 이미 Agg 맵이면 그대로
+      } catch (ClassCastException ignore) {
+        // 타입이 다르면 새로 초기화
+      }
+    }
+    Map<UUID, Agg> map = new HashMap<>();
+    ec.put(COUNT_MAP_KEY, map);
+    return map;
   }
 
   @Override
   public void afterWrite(@NonNull Chunk<? extends Article> items) {
-    Map<UUID, Agg> map = getAggMap();
-    if (map == null) {
-      log.warn("[알림] 집계 맵 누락 - 스킵");
+    //  최적화 모드에서는 writer가 EC에 Map<UUID,Integer>를 채우므로,
+    //  listener afterWrite 집계는 충돌 방지를 위해 스킵한다.
+    if (optimize) {
+      log.debug("[알림] writer 최적화 모드 - afterWrite 집계 스킵");
       return;
     }
 
+    Map<UUID, Agg> map = getOrInitAggMap();
     int candidates = 0, counted = 0;
+
     for (Article a : items) {
       if (a == null) continue;
       candidates++;
 
-      // 핵심: 연관 ID 우선, 없으면 읽기전용 FK 보조
       UUID interestId = null;
       if (a.getInterest() != null) {
-        // Hibernate 프록시여도 getId()는 초기화 없이 안전
-        interestId = a.getInterest().getId();
+        interestId = a.getInterest().getId(); // 프록시여도 getId()는 안전
       }
       if (interestId == null) {
-        interestId = a.getInterestId();
+        interestId = a.getInterestId(); // 보조
       }
-      if (interestId == null) continue; // 집계 불가
+      if (interestId == null) continue;
 
       map.compute(interestId, (k, v) -> {
         if (v == null) return new Agg(1);
@@ -85,76 +104,62 @@ public class ArticleNotificationListener extends ItemListenerSupport<Article, Ar
       });
       counted++;
     }
-    log.debug("[알림] afterWrite 집계: 후보 {}건 중 {}건 카운팅", candidates, counted);
+    log.debug("[알림] afterWrite 집계: 후보 {}건 중 {}건 카운팅(optimize={})", candidates, counted, optimize);
   }
 
   @Override
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public ExitStatus afterStep(@NonNull StepExecution stepExecution) {
-    // Writer가 EC에 Map<UUID,Integer> 형태로 누적해 둔 경우를 흡수/정규화
-    Object raw = stepExecution.getExecutionContext().get(COUNT_MAP_KEY);
-    Map<UUID, Agg> map;
+    var ec = stepExecution.getExecutionContext();
+    Object obj = ec.get(COUNT_MAP_KEY);
 
-    if (raw == null) {
-      log.debug("[알림] 이번 스텝에서 집계 없음(EC 비어있음)");
+    // 아무 것도 없으면 종료
+    if (!(obj instanceof Map) || ((Map<?, ?>) obj).isEmpty()) {
+      log.debug("[알림] 이번 스텝에서 집계 없음(optimize={})", optimize);
       return stepExecution.getExitStatus();
     }
 
-    if (raw instanceof Map<?, ?> anyMap) {
-      if (anyMap.isEmpty()) {
-        // 비어 있어도 타입을 Agg로 확정해 둠
-        map = new HashMap<>();
-        stepExecution.getExecutionContext().put(COUNT_MAP_KEY, map);
+    // 두 케이스 모두 처리:
+    // 1) optimize=false → Map<UUID, Agg>
+    // 2) optimize=true  → Map<UUID, Integer>
+    Map<UUID, Agg> aggMap = new HashMap<>();
+
+    Map<?, ?> raw = (Map<?, ?>) obj;
+    for (Map.Entry<?, ?> e : raw.entrySet()) {
+      Object key = e.getKey();
+      Object val = e.getValue();
+      if (!(key instanceof UUID)) continue;
+
+      UUID interestId = (UUID) key;
+      if (val instanceof Agg) {
+        aggMap.put(interestId, (Agg) val);
+      } else if (val instanceof Integer) {
+        Agg a = new Agg((Integer) val);
+        aggMap.put(interestId, a);
       } else {
-        Object sampleVal = anyMap.values().iterator().next();
-        if (sampleVal instanceof Agg) {
-          // 이미 리스너 집계(Map<UUID, Agg>) 형태
-          @SuppressWarnings("unchecked")
-          Map<UUID, Agg> casted = (Map<UUID, Agg>) anyMap;
-          map = casted;
-        } else if (sampleVal instanceof Integer) {
-          // Writer 집계(Map<UUID, Integer>)를 Agg로 변환하여 대체
-          Map<UUID, Agg> converted = new HashMap<>();
-          for (Map.Entry<?, ?> e : anyMap.entrySet()) {
-            Object k = e.getKey();
-            Object v = e.getValue();
-            if (k instanceof UUID key && v instanceof Integer cnt) {
-              converted.put(key, new Agg(cnt));
-            }
-          }
-          // EC에 Agg 맵으로 치환
-          stepExecution.getExecutionContext().put(COUNT_MAP_KEY, converted);
-          map = converted;
-          log.debug("[알림] Writer 집계를 Agg로 정규화: {}개", map.size());
-        } else {
-          log.warn("[알림] 지원하지 않는 집계 타입: {}", sampleVal.getClass().getName());
-          return stepExecution.getExitStatus();
-        }
+        log.warn("[알림] aggByInterest 값 타입 미지원: key={}, valueType={}", interestId, (val == null ? "null" : val.getClass()));
       }
-    } else {
-      log.warn("[알림] EC '{}' 값이 Map이 아님: {}", COUNT_MAP_KEY, raw.getClass().getName());
+    }
+
+    if (aggMap.isEmpty()) {
+      log.debug("[알림] 집계 변환 결과 없음(optimize={})", optimize);
       return stepExecution.getExitStatus();
     }
 
-    if (map.isEmpty()) {
-      log.debug("[알림] 이번 스텝에서 집계 없음");
-      return stepExecution.getExitStatus();
-    }
-
-    // 관심사 이름 벌크 로딩(지연로딩 금지, 한 번에)
-    Set<UUID> interestIds = map.keySet();
+    // 이름 벌크 로딩
+    Set<UUID> interestIds = aggMap.keySet();
     Map<UUID, String> names = interestRepository.findAllById(interestIds).stream()
         .collect(Collectors.toMap(Interest::getId, it -> {
           String name = it.getName();
           return (name == null || name.isBlank()) ? "관심사" : name;
         }));
 
-    int kinds = map.size();
+    int kinds = aggMap.size();
     int sentBatches = 0;
 
-    for (Map.Entry<UUID, Agg> e : map.entrySet()) {
-      UUID interestId = e.getKey();
-      Agg agg = e.getValue();
+    for (var entry : aggMap.entrySet()) {
+      UUID interestId = entry.getKey();
+      Agg agg = entry.getValue();
       agg.interestName = names.getOrDefault(interestId, "관심사");
 
       try {
@@ -180,7 +185,7 @@ public class ArticleNotificationListener extends ItemListenerSupport<Article, Ar
       }
     }
 
-    log.info("[알림] 관심사별 배치 알림 생성 완료: 관심사 종류 {}개, 발송 {}건", kinds, sentBatches);
+    log.info("[알림] 관심사별 배치 알림 생성 완료: 관심사 종류 {}개, 발송 {}건(optimize={})", kinds, sentBatches, optimize);
     return stepExecution.getExitStatus();
   }
 }

--- a/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
+++ b/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
@@ -49,7 +49,7 @@ public class ArticleNotificationListener extends ItemListenerSupport<Article, Ar
     private String interestName;
     private int count;
     public Agg(int count) {
-           this.count = count;
+      this.count = count;
     }
   }
   @Override
@@ -62,7 +62,12 @@ public class ArticleNotificationListener extends ItemListenerSupport<Article, Ar
 
   @SuppressWarnings("unchecked")
   private Map<UUID, Agg> getOrInitAggMap() {
-    var ec = StepSynchronizationManager.getContext().getStepExecution().getExecutionContext();
+    var sync = StepSynchronizationManager.getContext();
+    if (sync == null || sync.getStepExecution() == null) {
+      log.debug("[알림] StepSynchronizationContext 미존재 - afterWrite 집계 스킵");
+      return null;
+    }
+    var ec = sync.getStepExecution().getExecutionContext();
     Object obj = ec.get(COUNT_MAP_KEY);
 
     // writer 최적화 모드면 afterWrite는 스킵하므로 여기서 Map<UUID, Agg>를 사용할 일은 거의 없음
@@ -88,6 +93,9 @@ public class ArticleNotificationListener extends ItemListenerSupport<Article, Ar
     }
 
     Map<UUID, Agg> map = getOrInitAggMap();
+    if (map == null) {
+      return;
+    }
     int candidates = 0, counted = 0;
 
     for (Article a : items) {
@@ -96,9 +104,7 @@ public class ArticleNotificationListener extends ItemListenerSupport<Article, Ar
 
       UUID interestId = null;
       // FK 필드 직접 접근 우선 (lazy loading 회피)
-      try {
-        interestId = a.getInterestId();
-      } catch (Exception ignore) { /* 안전장치 */ }
+      interestId = a.getInterestId();
       if (interestId == null && a.getInterest() != null) {
         interestId = a.getInterest().getId();
       }

--- a/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
+++ b/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
@@ -89,11 +89,12 @@ public class ArticleNotificationListener extends ItemListenerSupport<Article, Ar
       candidates++;
 
       UUID interestId = null;
-      if (a.getInterest() != null) {
-        interestId = a.getInterest().getId(); // 프록시여도 getId()는 안전
-      }
-      if (interestId == null) {
-        interestId = a.getInterestId(); // 보조
+      // FK 필드 직접 접근 우선 (lazy loading 회피)
+      try {
+        interestId = a.getInterestId();
+        } catch (Exception ignore) { /* 안전장치 */ }
+      if (interestId == null && a.getInterest() != null) {
+        interestId = a.getInterest().getId();
       }
       if (interestId == null) continue;
 

--- a/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
+++ b/monew/src/main/java/com/spring/monew/batch/listener/ArticleNotificationListener.java
@@ -104,7 +104,9 @@ public class ArticleNotificationListener extends ItemListenerSupport<Article, Ar
 
       UUID interestId = null;
       // FK 필드 직접 접근 우선 (lazy loading 회피)
-      interestId = a.getInterestId();
+      try {
+        interestId = a.getInterestId();
+      } catch (Exception ignore) { /* 안전장치 */ }
       if (interestId == null && a.getInterest() != null) {
         interestId = a.getInterest().getId();
       }

--- a/monew/src/main/java/com/spring/monew/batch/writer/ArticleWriter.java
+++ b/monew/src/main/java/com/spring/monew/batch/writer/ArticleWriter.java
@@ -7,9 +7,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -18,12 +25,16 @@ public class ArticleWriter implements ItemWriter<Article> {
 
     private final ArticleRepository articleRepository;
 
+    // 시스템 프로퍼티 대신 Spring 설정 주입 (기본 false)
+    @Value("${monew.writer.optimize:false}")
+    private boolean optimize;
+
+    private static final String AGG_KEY = "aggByInterest";
+
     @Override
     public void write(Chunk<? extends Article> chunk) {
-        // 기본 false: 원본 동작 100% 유지. 필요 시 -Dmonew.writer.optimize=true로
-        boolean optimize = Boolean.parseBoolean(
-            System.getProperty("monew.writer.optimize", "false")
-        );
+
+        // ===== 최적화 ON: 기존 네가 만든 최적화 경로만 개선 =====
         if (optimize) {
             int saved = 0;
             int skipped = 0;
@@ -31,11 +42,17 @@ public class ArticleWriter implements ItemWriter<Article> {
             Set<String> seenUrls = new LinkedHashSet<>();
             List<Article> candidates = new ArrayList<>();
 
-            // 1) 후보 수집
+            // 1) 후보 수집 (가독성 좋은 블록 if)
             for (Article a : chunk) {
-                String url = a.getSourceUrl();
-                if (url == null || url.isBlank()) { skipped++; continue; }
-                if (!seenUrls.add(url)) { skipped++; continue; }
+                String url = (a != null) ? a.getSourceUrl() : null;
+                if (url == null || url.isBlank()) {
+                    skipped++;
+                    continue;
+                }
+                if (!seenUrls.add(url)) {
+                    skipped++;
+                    continue;
+                }
                 candidates.add(a);
             }
 
@@ -44,43 +61,59 @@ public class ArticleWriter implements ItemWriter<Article> {
                 ? Set.of()
                 : articleRepository.findExistingSourceUrls(seenUrls);
 
-            // 3) 실제 저장분을 관심사별로 집계
+            // 3) 실제 저장분을 관심사별로 집계(Map<UUID,Integer>)
             Map<UUID, Integer> writerAgg = new HashMap<>();
             for (Article a : candidates) {
                 String url = a.getSourceUrl();
-                if (existing.contains(url)) { skipped++; continue; }
+                if (existing.contains(url)) {
+                    skipped++;
+                    continue;
+                }
 
                 articleRepository.save(a);
                 saved++;
 
-                // Article에 읽기전용 FK 필드가 있어야 함: getInterestId()
+                // 읽기 전용 FK 필드(Article.getInterestId) 우선 사용
                 UUID interestId = null;
                 try {
-                    interestId = a.getInterestId(); // LAZY 회피
-                } catch (Exception ignore) { /* 안전 */ }
-
+                    interestId = a.getInterestId();
+                } catch (Exception ignore) { /* 안전장치 */ }
+                if (interestId == null && a.getInterest() != null) {
+                    // 프록시여도 getId()는 초기화 없이 안전
+                    interestId = a.getInterest().getId();
+                }
                 if (interestId != null) {
                     writerAgg.merge(interestId, 1, Integer::sum);
                 }
             }
 
-            // 4) ExecutionContext("aggByInterest")에 누적
+            // 4) ExecutionContext("aggByInterest")에 누적 (타입 안전)
             var ctx = StepSynchronizationManager.getContext();
             if (ctx != null && ctx.getStepExecution() != null) {
                 var ec = ctx.getStepExecution().getExecutionContext();
-                @SuppressWarnings("unchecked")
-                Map<UUID, Integer> total =
-                    (Map<UUID, Integer>) ec.get("aggByInterest");
+
+                Map<UUID, Integer> total = null;
+                Object obj = ec.get(AGG_KEY);
+                if (obj instanceof Map) {
+                    try {
+                        @SuppressWarnings("unchecked")
+                        Map<UUID, Integer> casted = (Map<UUID, Integer>) obj;
+                        total = casted;
+                    } catch (ClassCastException e) {
+                        log.warn("ExecutionContext '{}' 타입 불일치(Map<UUID,Integer> 기대). 새로 초기화합니다.", AGG_KEY, e);
+                    }
+                }
                 if (total == null) {
                     total = new HashMap<>();
-                    ec.put("aggByInterest", total);
+                    ec.put(AGG_KEY, total);
                 }
                 for (var e : writerAgg.entrySet()) {
                     total.merge(e.getKey(), e.getValue(), Integer::sum);
                 }
             }
-            // 통계 로그
-            log.info("청크 저장 완료: {} 개의 기사 {} 개 저장, {} 개 스킵", chunk.size(), saved, skipped);
+
+            log.info("청크 저장 완료: {} 개의 기사 {} 개 저장, {} 개 스킵 (optimize=ON)",
+                chunk.size(), saved, skipped);
             return;
         }
         for (Article article : chunk) {

--- a/monew/src/main/java/com/spring/monew/batch/writer/ArticleWriter.java
+++ b/monew/src/main/java/com/spring/monew/batch/writer/ArticleWriter.java
@@ -8,6 +8,8 @@ import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
 
+import java.util.*;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -17,8 +19,29 @@ public class ArticleWriter implements ItemWriter<Article> {
 
     @Override
     public void write(Chunk<? extends Article> chunk) {
+
+        int saved = 0;
+        int skipped = 0;
+
+        // 청크 내부 중복 제거(첫 등장만 저장 시도)
+        Set<String> seenUrls = new LinkedHashSet<>();
         for (Article article : chunk) {
+            String url = article.getSourceUrl();
+
+            if (url != null && !url.isBlank()) {
+                // 청크 내부 중복이면 스킵
+                if (!seenUrls.add(url)) {
+                    skipped++;
+                    continue;
+                }
+                // DB에 이미 있으면 스킵
+                if (articleRepository.existsBySourceUrl(url)) {
+                    skipped++;
+                    continue;
+                }
+            }
             articleRepository.save(article);
+            saved++;
         }
         log.info("청크 저장 완료: {} 개의 기사", chunk.size());
     }

--- a/monew/src/main/java/com/spring/monew/batch/writer/ArticleWriter.java
+++ b/monew/src/main/java/com/spring/monew/batch/writer/ArticleWriter.java
@@ -4,6 +4,7 @@ import com.spring.monew.article.domain.Article;
 import com.spring.monew.article.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
@@ -19,29 +20,71 @@ public class ArticleWriter implements ItemWriter<Article> {
 
     @Override
     public void write(Chunk<? extends Article> chunk) {
+        // 기본 false: 원본 동작 100% 유지. 필요 시 -Dmonew.writer.optimize=true로
+        boolean optimize = Boolean.parseBoolean(
+            System.getProperty("monew.writer.optimize", "false")
+        );
+        if (optimize) {
+            int saved = 0;
+            int skipped = 0;
 
-        int saved = 0;
-        int skipped = 0;
+            Set<String> seenUrls = new LinkedHashSet<>();
+            List<Article> candidates = new ArrayList<>();
 
-        // 청크 내부 중복 제거(첫 등장만 저장 시도)
-        Set<String> seenUrls = new LinkedHashSet<>();
-        for (Article article : chunk) {
-            String url = article.getSourceUrl();
+            // 1) 후보 수집
+            for (Article a : chunk) {
+                String url = a.getSourceUrl();
+                if (url == null || url.isBlank()) { skipped++; continue; }
+                if (!seenUrls.add(url)) { skipped++; continue; }
+                candidates.add(a);
+            }
 
-            if (url != null && !url.isBlank()) {
-                // 청크 내부 중복이면 스킵
-                if (!seenUrls.add(url)) {
-                    skipped++;
-                    continue;
-                }
-                // DB에 이미 있으면 스킵
-                if (articleRepository.existsBySourceUrl(url)) {
-                    skipped++;
-                    continue;
+            // 2) DB 존재 URL 일괄 조회 (N+1 제거)
+            Set<String> existing = seenUrls.isEmpty()
+                ? Set.of()
+                : articleRepository.findExistingSourceUrls(seenUrls);
+
+            // 3) 실제 저장분을 관심사별로 집계
+            Map<UUID, Integer> writerAgg = new HashMap<>();
+            for (Article a : candidates) {
+                String url = a.getSourceUrl();
+                if (existing.contains(url)) { skipped++; continue; }
+
+                articleRepository.save(a);
+                saved++;
+
+                // Article에 읽기전용 FK 필드가 있어야 함: getInterestId()
+                UUID interestId = null;
+                try {
+                    interestId = a.getInterestId(); // LAZY 회피
+                } catch (Exception ignore) { /* 안전 */ }
+
+                if (interestId != null) {
+                    writerAgg.merge(interestId, 1, Integer::sum);
                 }
             }
+
+            // 4) ExecutionContext("aggByInterest")에 누적
+            var ctx = StepSynchronizationManager.getContext();
+            if (ctx != null && ctx.getStepExecution() != null) {
+                var ec = ctx.getStepExecution().getExecutionContext();
+                @SuppressWarnings("unchecked")
+                Map<UUID, Integer> total =
+                    (Map<UUID, Integer>) ec.get("aggByInterest");
+                if (total == null) {
+                    total = new HashMap<>();
+                    ec.put("aggByInterest", total);
+                }
+                for (var e : writerAgg.entrySet()) {
+                    total.merge(e.getKey(), e.getValue(), Integer::sum);
+                }
+            }
+            // 통계 로그
+            log.info("청크 저장 완료: {} 개의 기사 {} 개 저장, {} 개 스킵", chunk.size(), saved, skipped);
+            return;
+        }
+        for (Article article : chunk) {
             articleRepository.save(article);
-            saved++;
         }
         log.info("청크 저장 완료: {} 개의 기사", chunk.size());
     }

--- a/monew/src/main/java/com/spring/monew/comment/service/impl/CommentServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/comment/service/impl/CommentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.spring.monew.comment.service.impl;
 
+import com.spring.monew.activity.repository.ActivitySyncRepository;
 import com.spring.monew.article.domain.Article;
 import com.spring.monew.article.repository.ArticleRepository;
 import com.spring.monew.comment.controller.dto.request.CommentRegisterRequest;
@@ -15,9 +16,11 @@ import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -26,6 +29,7 @@ public class CommentServiceImpl implements CommentService {
   private final CommentRepository commentRepository;
   private final UserRepository userRepository;
   private final ArticleRepository articleRepository;
+  private final ActivitySyncRepository activitySyncRepository;
 
   @Override
   @Transactional
@@ -37,6 +41,22 @@ public class CommentServiceImpl implements CommentService {
         () -> new NoSuchElementException("존재하지 않는 기사입니다."));
 
     Comment comment = commentRepository.save(new Comment(article, user, registerRequest.content()));
+
+    try {
+      activitySyncRepository.onCommentCreated(
+          comment.getId(),
+          user.getId(),
+          article.getId(),
+          article.getTitle(),
+          user.getNickname(),
+          comment.getContent(),
+          comment.getLikeCount(),
+          comment.getCreatedAt()
+      );
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (댓글 생성): commentId={}, userId={}, articleId={}",
+          comment.getId(), user.getId(), article.getId(), e);
+    }
 
     return new CommentDto(
         comment.getId(),
@@ -72,6 +92,25 @@ public class CommentServiceImpl implements CommentService {
 
     comment.update(updateRequest.content());
 
+    Article article = comment.getArticle();
+    User writer = comment.getUser();
+
+    try {
+      activitySyncRepository.onCommentCreated(
+          comment.getId(),
+          writer.getId(),
+          article.getId(),
+          article.getTitle(),
+          writer.getNickname(),
+          comment.getContent(),
+          comment.getLikeCount(),
+          comment.getCreatedAt()
+      );
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (댓글 수정→스냅샷 갱신): commentId={}, userId={}, articleId={}",
+          comment.getId(), writer.getId(), article.getId(), e);
+    }
+
     return new CommentDto(
         comment.getId(),
         comment.getArticle().getId(),
@@ -92,6 +131,10 @@ public class CommentServiceImpl implements CommentService {
     }
 
     commentRepository.deleteById(commentId);
+
+    try {
+      activitySyncRepository.onCommentDeleted(commentId, Instant.now());
+    } catch (Exception ignore) {}
   }
 
   @Override
@@ -102,5 +145,10 @@ public class CommentServiceImpl implements CommentService {
     }
 
     commentRepository.deletePhysicalById(commentId);
+    try {
+      activitySyncRepository.onCommentDeleted(commentId, Instant.now());
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (댓글 물리 삭제): commentId={}", commentId, e);
+    }
   }
 }

--- a/monew/src/main/java/com/spring/monew/commentlike/service/impl/CommentLikeServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/commentlike/service/impl/CommentLikeServiceImpl.java
@@ -1,27 +1,26 @@
 package com.spring.monew.commentlike.service.impl;
 
-import com.spring.monew.activity.repository.ActivitySyncRepository;
+import com.spring.monew.activity.repository.ActivitySyncRepository;              // ★ Added
 import com.spring.monew.comment.domain.Comment;
 import com.spring.monew.comment.repository.CommentRepository;
 import com.spring.monew.commentlike.controller.dto.response.CommentLikeDto;
 import com.spring.monew.commentlike.domain.CommentLike;
 import com.spring.monew.commentlike.repository.CommentLikeRepository;
 import com.spring.monew.commentlike.service.CommentLikeService;
-import com.spring.monew.interest.domain.Interest;
-import com.spring.monew.notification.domain.NotificationResourceType;
-import com.spring.monew.notification.service.NotificationService;
-import com.spring.monew.subscription.domain.Subscription;
+// import com.spring.monew.notification.domain.NotificationResourceType;        // (알림 재개 시 사용)
+// import com.spring.monew.notification.service.NotificationService;            // (알림 재개 시 사용)
 import com.spring.monew.user.domain.User;
 import com.spring.monew.user.repository.UserRepository;
-import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import lombok.extern.slf4j.Slf4j;                                               // ★ Added
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;       // ★ Added
+import org.springframework.transaction.support.TransactionSynchronizationManager; // ★ Added
 
-@Slf4j
+@Slf4j                                                                          // ★ Added
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -30,15 +29,15 @@ public class CommentLikeServiceImpl implements CommentLikeService {
   private final CommentLikeRepository commentLikeRepository;
   private final CommentRepository commentRepository;
   private final UserRepository userRepository;
-  private final ActivitySyncRepository activitySyncRepository;
-  private final NotificationService notificationService;
+  private final ActivitySyncRepository activitySyncRepository;                  // ★ Added
+  // private final NotificationService notificationService;                      // (알림 재개 시 사용)
 
   @Override
   @Transactional
   public CommentLikeDto addCommentLike(UUID commentId, UUID userId) {
     Comment comment = commentRepository.findById(commentId).orElseThrow(
-        () -> new NoSuchElementException("존재하지 않는 댓글 입니다."));
-
+        () -> new NoSuchElementException("존재하지 않는 댓글 입니다.")
+    );
     User user = userRepository.findById(userId).orElseThrow(
         () -> new NoSuchElementException("존재하지 않는 유저 입니다.")
     );
@@ -51,35 +50,45 @@ public class CommentLikeServiceImpl implements CommentLikeService {
 
     CommentLike commentLike = commentLikeRepository.save(new CommentLike(comment, user));
 
-    try {
-      activitySyncRepository.onCommentLiked(
-          commentLike.getId(),                // likeEventId
-          user.getId(),                       // likedByUserId
-          comment.getId(),                    // commentId
-          comment.getArticle().getId(),       // articleId
-          comment.getArticle().getTitle(),    // articleTitleSnapshot
-          comment.getUser().getId(),          // commentUserId
-          comment.getUser().getNickname(),    // commentUserNicknameSnapshot
-          comment.getContent(),               // commentContentSnapshot
-          comment.getLikeCount(),             // commentLikeCountSnapshot (long)
-          comment.getCreatedAt(),             // commentCreatedAtSnapshot (Instant)
-          commentLike.getCreatedAt()          // likedAt (Instant)
-      );
-    } catch (Exception e) {
-      log.warn("활동 동기화 실패 (댓글 좋아요 생성): likeId={}, commentId={}, likedByUserId={}, articleId={}",
-          commentLike.getId(), comment.getId(), user.getId(), comment.getArticle().getId(), e);
-    }
+    afterCommit(() -> {                                                         // ★ Added
+      try {
+        activitySyncRepository.onCommentLiked(
+            commentLike.getId(),                // likeEventId
+            user.getId(),                       // likedByUserId
+            comment.getId(),                    // commentId
+            comment.getArticle().getId(),       // articleId
+            comment.getArticle().getTitle(),    // articleTitleSnapshot
+            comment.getUser().getId(),          // commentUserId
+            comment.getUser().getNickname(),    // commentUserNicknameSnapshot
+            comment.getContent(),               // commentContentSnapshot
+            comment.getLikeCount(),             // commentLikeCountSnapshot
+            comment.getCreatedAt(),             // commentCreatedAtSnapshot
+            commentLike.getCreatedAt()          // likedAt
+        );
+      } catch (Exception e) {
+        log.warn("활동 동기화 실패 (댓글 좋아요 생성 afterCommit): likeId={}, commentId={}, likedByUserId={}, articleId={}",
+            commentLike.getId(), comment.getId(), user.getId(), comment.getArticle().getId(), e);
+      }
+    });
 
-//    UUID commentAuthorId = comment.getUser().getId();
-//    if (!commentAuthorId.equals(userId)) {
-//      String content = user.getNickname() + "님이 나의 댓글을 좋아합니다.";
-//      notificationService.create(
-//          commentAuthorId,
-//          content,
-//          NotificationResourceType.COMMENT, // 관련 리소스 = 댓글
-//          comment.getId()
-//      );
-//    }
+    // 알림 재개 시 커밋 이후로 지연 실행
+    // afterCommit(() -> {
+    //   UUID commentAuthorId = comment.getUser().getId();
+    //   if (!commentAuthorId.equals(userId)) {
+    //     String content = user.getNickname() + "님이 나의 댓글을 좋아합니다.";
+    //     try {
+    //       notificationService.create(
+    //           commentAuthorId,
+    //           content,
+    //           NotificationResourceType.COMMENT,
+    //           comment.getId()
+    //       );
+    //     } catch (Exception e) {
+    //       log.warn("알림 발송 실패 (댓글 좋아요): likeId={}, commentId={}, toUserId={}",
+    //           commentLike.getId(), comment.getId(), commentAuthorId, e);
+    //     }
+    //   }
+    // });
 
     return new CommentLikeDto(
         commentLike.getId(),
@@ -104,13 +113,27 @@ public class CommentLikeServiceImpl implements CommentLikeService {
 
     commentLike.getComment().decrementLikeCount();
 
-    try {
-      activitySyncRepository.onCommentLikeCanceled(commentLike.getId());
-    } catch (Exception e) {
-      log.warn("활동 동기화 실패 (댓글 좋아요 취소): likeId={}, commentId={}, userId={}",
-          commentLike.getId(), commentId, userId, e);
-    }
-
     commentLikeRepository.delete(commentLike);
+
+    // 활동 스냅샷 삭제도 커밋 이후로 지연 (정합성 보장)
+    afterCommit(() -> {
+      try {
+        activitySyncRepository.onCommentLikeCanceled(commentLike.getId());
+      } catch (Exception e) {
+        log.warn("활동 동기화 실패 (댓글 좋아요 취소 afterCommit): likeId={}, commentId={}, userId={}",
+            commentLike.getId(), commentId, userId, e);
+      }
+    });
+  }
+
+  // === 커밋 이후 실행 유틸 ===
+  private void afterCommit(Runnable task) {
+    if (TransactionSynchronizationManager.isActualTransactionActive()) {
+      TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        @Override public void afterCommit() { task.run(); }
+      });
+    } else {
+      task.run();
+    }
   }
 }

--- a/monew/src/main/java/com/spring/monew/commentlike/service/impl/CommentLikeServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/commentlike/service/impl/CommentLikeServiceImpl.java
@@ -1,5 +1,6 @@
 package com.spring.monew.commentlike.service.impl;
 
+import com.spring.monew.activity.repository.ActivitySyncRepository;
 import com.spring.monew.comment.domain.Comment;
 import com.spring.monew.comment.repository.CommentRepository;
 import com.spring.monew.commentlike.controller.dto.response.CommentLikeDto;
@@ -7,6 +8,8 @@ import com.spring.monew.commentlike.domain.CommentLike;
 import com.spring.monew.commentlike.repository.CommentLikeRepository;
 import com.spring.monew.commentlike.service.CommentLikeService;
 import com.spring.monew.interest.domain.Interest;
+import com.spring.monew.notification.domain.NotificationResourceType;
+import com.spring.monew.notification.service.NotificationService;
 import com.spring.monew.subscription.domain.Subscription;
 import com.spring.monew.user.domain.User;
 import com.spring.monew.user.repository.UserRepository;
@@ -14,9 +17,11 @@ import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -25,6 +30,8 @@ public class CommentLikeServiceImpl implements CommentLikeService {
   private final CommentLikeRepository commentLikeRepository;
   private final CommentRepository commentRepository;
   private final UserRepository userRepository;
+  private final ActivitySyncRepository activitySyncRepository;
+  private final NotificationService notificationService;
 
   @Override
   @Transactional
@@ -43,6 +50,36 @@ public class CommentLikeServiceImpl implements CommentLikeService {
     comment.incrementLikeCount();
 
     CommentLike commentLike = commentLikeRepository.save(new CommentLike(comment, user));
+
+    try {
+      activitySyncRepository.onCommentLiked(
+          commentLike.getId(),                // likeEventId
+          user.getId(),                       // likedByUserId
+          comment.getId(),                    // commentId
+          comment.getArticle().getId(),       // articleId
+          comment.getArticle().getTitle(),    // articleTitleSnapshot
+          comment.getUser().getId(),          // commentUserId
+          comment.getUser().getNickname(),    // commentUserNicknameSnapshot
+          comment.getContent(),               // commentContentSnapshot
+          comment.getLikeCount(),             // commentLikeCountSnapshot (long)
+          comment.getCreatedAt(),             // commentCreatedAtSnapshot (Instant)
+          commentLike.getCreatedAt()          // likedAt (Instant)
+      );
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (댓글 좋아요 생성): likeId={}, commentId={}, likedByUserId={}, articleId={}",
+          commentLike.getId(), comment.getId(), user.getId(), comment.getArticle().getId(), e);
+    }
+
+//    UUID commentAuthorId = comment.getUser().getId();
+//    if (!commentAuthorId.equals(userId)) {
+//      String content = user.getNickname() + "님이 나의 댓글을 좋아합니다.";
+//      notificationService.create(
+//          commentAuthorId,
+//          content,
+//          NotificationResourceType.COMMENT, // 관련 리소스 = 댓글
+//          comment.getId()
+//      );
+//    }
 
     return new CommentLikeDto(
         commentLike.getId(),
@@ -66,6 +103,13 @@ public class CommentLikeServiceImpl implements CommentLikeService {
         .orElseThrow(() -> new NoSuchElementException("존재하지 않는 좋아요 입니다"));
 
     commentLike.getComment().decrementLikeCount();
+
+    try {
+      activitySyncRepository.onCommentLikeCanceled(commentLike.getId());
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (댓글 좋아요 취소): likeId={}, commentId={}, userId={}",
+          commentLike.getId(), commentId, userId, e);
+    }
 
     commentLikeRepository.delete(commentLike);
   }

--- a/monew/src/main/java/com/spring/monew/commentlike/service/impl/CommentLikeServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/commentlike/service/impl/CommentLikeServiceImpl.java
@@ -7,8 +7,8 @@ import com.spring.monew.commentlike.controller.dto.response.CommentLikeDto;
 import com.spring.monew.commentlike.domain.CommentLike;
 import com.spring.monew.commentlike.repository.CommentLikeRepository;
 import com.spring.monew.commentlike.service.CommentLikeService;
-// import com.spring.monew.notification.domain.NotificationResourceType;        // (알림 재개 시 사용)
-// import com.spring.monew.notification.service.NotificationService;            // (알림 재개 시 사용)
+import com.spring.monew.notification.domain.NotificationResourceType;        // (알림 재개 시 사용)
+import com.spring.monew.notification.service.NotificationService;            // (알림 재개 시 사용)
 import com.spring.monew.user.domain.User;
 import com.spring.monew.user.repository.UserRepository;
 import java.util.NoSuchElementException;
@@ -30,7 +30,7 @@ public class CommentLikeServiceImpl implements CommentLikeService {
   private final CommentRepository commentRepository;
   private final UserRepository userRepository;
   private final ActivitySyncRepository activitySyncRepository;                  // ★ Added
-  // private final NotificationService notificationService;                      // (알림 재개 시 사용)
+  private final NotificationService notificationService;                      // (알림 재개 시 사용)
 
   @Override
   @Transactional
@@ -71,24 +71,22 @@ public class CommentLikeServiceImpl implements CommentLikeService {
       }
     });
 
-    // 알림 재개 시 커밋 이후로 지연 실행
-    // afterCommit(() -> {
-    //   UUID commentAuthorId = comment.getUser().getId();
-    //   if (!commentAuthorId.equals(userId)) {
-    //     String content = user.getNickname() + "님이 나의 댓글을 좋아합니다.";
-    //     try {
-    //       notificationService.create(
-    //           commentAuthorId,
-    //           content,
-    //           NotificationResourceType.COMMENT,
-    //           comment.getId()
-    //       );
-    //     } catch (Exception e) {
-    //       log.warn("알림 발송 실패 (댓글 좋아요): likeId={}, commentId={}, toUserId={}",
-    //           commentLike.getId(), comment.getId(), commentAuthorId, e);
-    //     }
-    //   }
-    // });
+       //좋아요 알림
+       UUID commentAuthorId = comment.getUser().getId();
+       if (!commentAuthorId.equals(userId)) {
+         String content = user.getNickname() + "님이 나의 댓글을 좋아합니다.";
+         try {
+           notificationService.create(
+               commentAuthorId,
+               content,
+               NotificationResourceType.COMMENT, // 관련 리소스 = 댓글
+               comment.getId()
+           );
+         } catch (Exception e) {
+           log.warn("알림 발송 실패 (댓글 좋아요): likeId={}, commentId={}, toUserId={}",
+               commentLike.getId(), comment.getId(), commentAuthorId, e);
+         }
+       }
 
     return new CommentLikeDto(
         commentLike.getId(),

--- a/monew/src/main/java/com/spring/monew/notification/controller/NotificationController.java
+++ b/monew/src/main/java/com/spring/monew/notification/controller/NotificationController.java
@@ -1,59 +1,79 @@
 package com.spring.monew.notification.controller;
 
+import com.spring.monew.auth.config.HeaderUserAuthentication;
 import com.spring.monew.notification.controller.dto.response.BulkConfirmResultDto;
 import com.spring.monew.notification.controller.dto.response.CursorPageResponseNotificationDto;
 import com.spring.monew.notification.controller.dto.response.NotificationConfirmResponseDto;
 import com.spring.monew.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.time.Instant;
 import java.util.UUID;
 
-@Validated
 @RestController
 @RequestMapping("/api/notifications")
+@Validated
 @RequiredArgsConstructor
 public class NotificationController {
 
   private final NotificationService notificationService;
 
-  // 알림 목록 조회 (커서 기반)
-  @Operation(summary = "알림 목록 조회")
+  private UUID extractUserId(Principal principal) {
+    if (principal instanceof HeaderUserAuthentication auth) {
+      try {
+        String s = (String) auth.getPrincipal();
+        if (s != null && !s.isBlank()) return UUID.fromString(s);
+      } catch (Exception ignored) {}
+    }
+    return null;
+  }
+
+  // 목록: 미확인만, 최신순 커서
   @GetMapping
   public CursorPageResponseNotificationDto list(
-      @RequestHeader("Monew-Request-User-ID")
-      @Parameter(description = "요청 사용자 ID") UUID userId,
+      Principal principal,
       @RequestParam(required = false) String cursor,
-      @RequestParam(required = false)
-      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant after,
+      @RequestParam(required = false) Instant after,
       @RequestParam(defaultValue = "20") @Min(1) @Max(100) int limit
   ) {
+    UUID userId = extractUserId(principal);
+    if (userId == null) {
+      throw new org.springframework.web.server.ResponseStatusException(
+          org.springframework.http.HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+    }
     return notificationService.list(userId, cursor, after, limit);
   }
 
-  // 알림 확인(단건)
-  @Operation(summary = "알림 확인(단건)")
+  // 단건 확인: PATCH /api/notifications/{notificationId}
   @PatchMapping("/{notificationId}")
+  @Operation(summary = "알림 확인")
   public NotificationConfirmResponseDto confirmOne(
-      @RequestHeader("Monew-Request-User-ID") UUID userId,
+      Principal principal,
       @PathVariable UUID notificationId
   ) {
+    UUID userId = extractUserId(principal);
+    if (userId == null) {
+      throw new org.springframework.web.server.ResponseStatusException(
+          org.springframework.http.HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+    }
     return notificationService.confirmOne(userId, notificationId);
   }
 
-  // 전체 알림 확인(일괄)
-  @Operation(summary = "전체 알림 확인(일괄)")
+  // 전체 확인: PATCH /api/notifications
   @PatchMapping
-  public BulkConfirmResultDto confirmAll(
-      @RequestHeader("Monew-Request-User-ID") UUID userId
-  ) {
+  @Operation(summary = "전체 알림 확인")
+  public BulkConfirmResultDto confirmAll(Principal principal) {
+    UUID userId = extractUserId(principal);
+    if (userId == null) {
+      throw new org.springframework.web.server.ResponseStatusException(
+          org.springframework.http.HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+    }
     return notificationService.confirmAll(userId);
   }
 }

--- a/monew/src/main/java/com/spring/monew/notification/controller/dto/response/NotificationDto.java
+++ b/monew/src/main/java/com/spring/monew/notification/controller/dto/response/NotificationDto.java
@@ -42,5 +42,8 @@ public record NotificationDto(
     NotificationResourceType resourceType,
 
     @Schema(description = "관련 리소스 ID", format = "uuid", example = "de9e6b6e-1e8e-4bf-98db-5f1f37a4e7a2", requiredMode = Schema.RequiredMode.REQUIRED)
-    UUID resourceId
+    UUID resourceId,
+
+    @Schema(description = "관련 리소스 표시명(예: 관심사명)", example = "게임")
+    String resourceName
 ) {}

--- a/monew/src/main/java/com/spring/monew/notification/domain/Notification.java
+++ b/monew/src/main/java/com/spring/monew/notification/domain/Notification.java
@@ -2,141 +2,64 @@ package com.spring.monew.notification.domain;
 
 import jakarta.persistence.*;
 import java.time.Instant;
-import java.util.Objects;
 import java.util.UUID;
 import lombok.Getter;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 @Getter
 @Entity
-@Table(
-    name = "notifications",
-    indexes = {
-        // 목록 조회용(사용자별 최신순) +  id
-        @Index(name = "idx_notif_user_created_id_desc",
-            columnList = "user_id, created_at, id"),
-        // 확인여부 + 갱신시각
-        @Index(name = "idx_notif_confirmed_updated",
-            columnList = "confirmed, updated_at")
-    }
-)
+@Table(name = "notifications")
 public class Notification {
 
   @Id
-  @Column(name = "id", nullable = false, updatable = false, columnDefinition = "uuid")
+  @GeneratedValue
   private UUID id;
 
-  @Column(name = "user_id", nullable = false, updatable = false, columnDefinition = "uuid")
+  @Column(name = "user_id", nullable = false, columnDefinition = "uuid")
   private UUID userId;
 
   @Column(name = "content", nullable = false, length = 255)
   private String content;
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "resource_type", nullable = false, length = 30)
+  private NotificationResourceType resourceType;
+
+  @Column(name = "resource_id", nullable = false, columnDefinition = "uuid")
+  private UUID resourceId;
+
   @Column(name = "confirmed", nullable = false)
   private boolean confirmed;
 
-  // PostgreSQL ENUM 사용 시
-  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
-  @Column(name = "resource_type", nullable = false, columnDefinition = "resource_type")
-  private NotificationResourceType resourceType; // NOT NULL
-
-  @Column(name = "resource_id", nullable = false, columnDefinition = "uuid")
-  private UUID resourceId; // NOT NULL
-
-  @Column(name = "created_at", nullable = false, updatable = false)
+  @Column(name = "created_at", nullable = false, columnDefinition = "timestamptz")
   private Instant createdAt;
 
-  @Column(name = "updated_at")
+  @Column(name = "updated_at", nullable = false, columnDefinition = "timestamptz")
   private Instant updatedAt;
 
-  protected Notification() {}
-
-  private Notification(
-      UUID id,
-      UUID userId,
-      String content,
-      boolean confirmed,
-      NotificationResourceType resourceType,
-      UUID resourceId,
-      Instant createdAt,
-      Instant updatedAt
-  ) {
-    this.id = id;
-    this.userId = userId;
-    this.content = content;
-    this.confirmed = confirmed;
-    this.resourceType = resourceType;
-    this.resourceId = resourceId;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
-  }
-
-  // 필수값 검증
-  public static Notification of(
-      UUID userId,
-      String content,
-      NotificationResourceType resourceType,
-      UUID resourceId
-  ) {
-    Objects.requireNonNull(userId, "userId");
-    Objects.requireNonNull(content, "content");
-    Objects.requireNonNull(resourceType, "resourceType");
-    Objects.requireNonNull(resourceId, "resourceId");
-
-    String normalized = content.trim();
-    if (normalized.length() > 255) {
-      throw new IllegalArgumentException("Content length must not exceed 255 characters");
-    }
-
-    Instant now = Instant.now();
-    return new Notification(
-        UUID.randomUUID(),
-        userId,
-        normalized,
-        false,
-        resourceType,
-        resourceId,
-        now,
-        null
-    );
-  }
-
-  public void confirm() {
-    if (!this.confirmed) {
-      this.confirmed = true;
-    }
-  }
-
-  public void changeContent(String newContent) {
-    Objects.requireNonNull(newContent, "content");
-    String normalized = newContent.trim();
-    if (normalized.length() > 255) {
-      throw new IllegalArgumentException("Content length must not exceed 255 characters");
-    }
-    this.content = normalized;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof Notification that)) return false;
-    return Objects.equals(id, that.id);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(id);
+  public static Notification of(UUID userId, String content,
+      NotificationResourceType type, UUID resourceId) {
+    Notification n = new Notification();
+    n.userId = userId;
+    n.content = content;
+    n.resourceType = type;
+    n.resourceId = resourceId;
+    n.confirmed = false;
+    return n;
   }
 
   @PrePersist
-  void onCreate() {
-    if (this.id == null) this.id = UUID.randomUUID();
-    if (this.createdAt == null) this.createdAt = Instant.now();
+  void onInsert() {
+    Instant now = Instant.now();
+    if (this.createdAt == null) this.createdAt = now;
+    if (this.updatedAt == null) this.updatedAt = now;
   }
 
   @PreUpdate
   void onUpdate() {
     this.updatedAt = Instant.now();
+  }
+
+  public void confirm() {
+    this.confirmed = true;
   }
 }

--- a/monew/src/main/java/com/spring/monew/notification/domain/NotificationResourceType.java
+++ b/monew/src/main/java/com/spring/monew/notification/domain/NotificationResourceType.java
@@ -2,26 +2,30 @@ package com.spring.monew.notification.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
 import java.util.Locale;
 
 public enum NotificationResourceType {
   ARTICLE, COMMENT, LIKE, SUBSCRIPTION;
 
-  // 잘못된 값이면 400
   @JsonCreator
   public static NotificationResourceType from(String value) {
     if (value == null) throw new IllegalArgumentException("resourceType is required");
+    String v = value.trim().toLowerCase(Locale.ROOT);
+    if ("interest".equals(v)) return SUBSCRIPTION;
     try {
-      return valueOf(value.trim().toUpperCase(Locale.ROOT));
+      return valueOf(v.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException("Unsupported resourceType: " + value);
     }
   }
 
-  //
   @JsonValue
   public String toJson() {
-    return name().toLowerCase(Locale.ROOT);
+    return switch (this) {
+      case SUBSCRIPTION -> "interest";
+      case COMMENT -> "comment";
+      case ARTICLE -> "article";
+      case LIKE -> "like";
+    };
   }
 }

--- a/monew/src/main/java/com/spring/monew/notification/service/NotificationService.java
+++ b/monew/src/main/java/com/spring/monew/notification/service/NotificationService.java
@@ -1,11 +1,15 @@
 package com.spring.monew.notification.service;
 
+import com.spring.monew.interest.repository.InterestRepository;
 import com.spring.monew.notification.controller.dto.response.BulkConfirmResultDto;
 import com.spring.monew.notification.controller.dto.response.CursorPageResponseNotificationDto;
 import com.spring.monew.notification.controller.dto.response.NotificationConfirmResponseDto;
 import com.spring.monew.notification.controller.dto.response.NotificationDto;
 import com.spring.monew.notification.domain.Notification;
+import com.spring.monew.notification.domain.NotificationResourceType;
 import com.spring.monew.notification.repository.NotificationRepository;
+import java.util.Collection;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -28,6 +32,7 @@ public class NotificationService {
   private static final int MAX_LIMIT = 100;
 
   private final NotificationRepository repository;
+  private final InterestRepository interestRepository;
 
   // ===== 목록 조회 (커서 기반) =====
   @Transactional(readOnly = true)
@@ -62,16 +67,25 @@ public class NotificationService {
     }
 
     final List<NotificationDto> content = entities.stream()
-        .map(n -> new NotificationDto(
-            n.getId(),
-            n.getCreatedAt(),
-            n.getUpdatedAt(),
-            n.isConfirmed(),
-            n.getUserId(),
-            n.getContent(),
-            n.getResourceType(),   // DTO가 enum(NotificationResourceType) 받음
-            n.getResourceId()
-        ))
+        .map(n -> {
+          String resourceName = null;
+          if (n.getResourceType() == NotificationResourceType.SUBSCRIPTION && n.getResourceId() != null) {
+            resourceName = interestRepository.findById(n.getResourceId())
+                .map(i -> i.getName())     // import 없이 이름만 가져오기
+                .orElse(null);
+          }
+          return new NotificationDto(
+              n.getId(),
+              n.getCreatedAt(),
+              n.getUpdatedAt(),   // 없다면 null 유지
+              n.isConfirmed(),
+              n.getUserId(),
+              n.getContent(),
+              n.getResourceType(),
+              n.getResourceId(),
+              resourceName        // ✅ 여기 채워 넣기
+          );
+        })
         .toList();
 
     String nextCursor = null;
@@ -155,6 +169,27 @@ public class NotificationService {
       throw new IllegalArgumentException("Invalid cursor. expected 'createdAt|id'");
     }
     return new CursorDecoded(Instant.parse(parts[0]), UUID.fromString(parts[1]));
+  }
+
+  @Transactional
+  public void create(UUID userId, String content, NotificationResourceType type, UUID resourceId) {
+    Objects.requireNonNull(userId, "userId");
+    Objects.requireNonNull(content, "content");
+    Objects.requireNonNull(type, "type");
+    Objects.requireNonNull(resourceId, "resourceId");
+
+    Notification n = Notification.of(userId, content, type, resourceId);
+    repository.save(n);
+  }
+
+  @Transactional
+  public void createForUsers(Collection<UUID> userIds, String content,
+      NotificationResourceType type, UUID resourceId) {
+    if (userIds == null || userIds.isEmpty()) return;
+    List<Notification> list = userIds.stream()
+        .map(uid -> Notification.of(uid, content, type, resourceId))
+        .toList();
+    repository.saveAll(list);
   }
 
   // DB 시간 우선 사용 — 예외를 숨기지 않고 그대로 던져 원인 파악 가능

--- a/monew/src/main/java/com/spring/monew/subscription/repository/SubscriptionRepository.java
+++ b/monew/src/main/java/com/spring/monew/subscription/repository/SubscriptionRepository.java
@@ -1,13 +1,19 @@
 package com.spring.monew.subscription.repository;
 
 import com.spring.monew.subscription.domain.Subscription;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
   Optional<Subscription> findByUser_IdAndInterest_Id(UUID userId, UUID interestId);
 
   boolean existsByUser_IdAndInterest_Id(UUID userId, UUID interestId);
+  @Query("select s.user.id from Subscription s where s.interest.id = :interestId")
+  List<UUID> findUserIdsByInterestId(UUID interestId);
+
+  long countByInterest_Id(UUID interestId);
 }

--- a/monew/src/main/java/com/spring/monew/subscription/service/impl/SubscriptionServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/subscription/service/impl/SubscriptionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.spring.monew.subscription.service.impl;
 
+import com.spring.monew.activity.repository.ActivitySyncRepository;
 import com.spring.monew.interest.domain.Interest;
 import com.spring.monew.interest.repository.InterestRepository;
 import com.spring.monew.subscription.controller.dto.response.SubscriptionDto;
@@ -13,9 +14,11 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -24,6 +27,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
   private final SubscriptionRepository subscriptionRepository;
   private final UserRepository userRepository;
   private final InterestRepository interestRepository;
+  private final ActivitySyncRepository activitySyncRepository;
 
   @Override
   @Transactional
@@ -41,6 +45,22 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     interest.incrementSubscriptionsCount();
 
     Subscription subscription = subscriptionRepository.save(new Subscription(user, interest));
+
+    try {
+      activitySyncRepository.onSubscribed(
+          subscription.getId(),
+          user.getId(),
+          interest.getId(),
+          interest.getName(),
+          interest.getKeywords(),
+          interest.getSubscriptionsCount(),
+          subscription.getCreatedAt()
+      );
+    } catch (Exception e) {
+      // 실패 시 본 기능은 유지하고 경고 로그 + 스택트레이스 남김
+      log.warn("활동 동기화 실패 (구독 생성): subscriptionId={}, userId={}, interestId={}",
+          subscription.getId(), user.getId(), interest.getId(), e);
+    }
 
     return new SubscriptionDto(
         subscription.getId(),
@@ -62,5 +82,11 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     subscription.getInterest().decrementSubscriptionsCount();
 
     subscriptionRepository.delete(subscription);
+    try {
+      activitySyncRepository.onUnsubscribed(subscription.getId());
+    } catch (Exception e) {
+      log.warn("활동 동기화 실패 (구독 해제): subscriptionId={}, userId={}, interestId={}",
+          subscription.getId(), userId, interestId, e);
+    }
   }
 }

--- a/monew/src/main/java/com/spring/monew/subscription/service/impl/SubscriptionServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/subscription/service/impl/SubscriptionServiceImpl.java
@@ -98,7 +98,6 @@ public class SubscriptionServiceImpl implements SubscriptionService {
       }
     });
   }
-
   // 트랜잭션 커밋 이후(afterCommit)에 작업 실행. 트랜잭션 없으면 즉시 실행(기존 동작 호환)
   private void afterCommit(Runnable task) {
     if (TransactionSynchronizationManager.isActualTransactionActive()) {

--- a/monew/src/main/java/com/spring/monew/subscription/service/impl/SubscriptionServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/subscription/service/impl/SubscriptionServiceImpl.java
@@ -17,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -46,21 +48,24 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
     Subscription subscription = subscriptionRepository.save(new Subscription(user, interest));
 
-    try {
-      activitySyncRepository.onSubscribed(
-          subscription.getId(),
-          user.getId(),
-          interest.getId(),
-          interest.getName(),
-          interest.getKeywords(),
-          interest.getSubscriptionsCount(),
-          subscription.getCreatedAt()
-      );
-    } catch (Exception e) {
-      // 실패 시 본 기능은 유지하고 경고 로그 + 스택트레이스 남김
-      log.warn("활동 동기화 실패 (구독 생성): subscriptionId={}, userId={}, interestId={}",
-          subscription.getId(), user.getId(), interest.getId(), e);
-    }
+    // 커밋 이후에만 읽기 모델(스냅샷) 동기화
+    afterCommit(() -> {
+      try {
+        activitySyncRepository.onSubscribed(
+            subscription.getId(),
+            user.getId(),
+            interest.getId(),
+            interest.getName(),
+            interest.getKeywords(),
+            interest.getSubscriptionsCount(),
+            subscription.getCreatedAt()
+        );
+      } catch (Exception e) {
+        // 실패 시 본 기능은 유지하고 경고 로그 + 스택트레이스 남김
+        log.warn("활동 동기화 실패 (구독 생성 afterCommit): subscriptionId={}, userId={}, interestId={}",
+            subscription.getId(), user.getId(), interest.getId(), e);
+      }
+    });
 
     return new SubscriptionDto(
         subscription.getId(),
@@ -82,11 +87,26 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     subscription.getInterest().decrementSubscriptionsCount();
 
     subscriptionRepository.delete(subscription);
-    try {
-      activitySyncRepository.onUnsubscribed(subscription.getId());
-    } catch (Exception e) {
-      log.warn("활동 동기화 실패 (구독 해제): subscriptionId={}, userId={}, interestId={}",
-          subscription.getId(), userId, interestId, e);
+
+    // 커밋 이후에만 읽기 모델(스냅샷) 동기화
+    afterCommit(() -> {
+      try {
+        activitySyncRepository.onUnsubscribed(subscription.getId());
+      } catch (Exception e) {
+        log.warn("활동 동기화 실패 (구독 해제 afterCommit): subscriptionId={}, userId={}, interestId={}",
+            subscription.getId(), userId, interestId, e);
+      }
+    });
+  }
+
+  // 트랜잭션 커밋 이후(afterCommit)에 작업 실행. 트랜잭션 없으면 즉시 실행(기존 동작 호환)
+  private void afterCommit(Runnable task) {
+    if (TransactionSynchronizationManager.isActualTransactionActive()) {
+      TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        @Override public void afterCommit() { task.run(); }
+      });
+    } else {
+      task.run();
     }
   }
 }


### PR DESCRIPTION
## Issues
- closed #이슈번호

## ✔️  Check-list
- [ ] : Label을 지정해 주세요.
- [ ] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 활동 내역 기능 구현 정리
- 알림 기능 구현 정리
## 📷 Screenshot

## 📚 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 본인·지정 사용자 활동 조회 API 추가(인증·소유권 검증 포함)
  * 활동 동기화 이벤트 콜백(구독/댓글/좋아요 등) 및 배치 알림 리스너 추가

* **개선 사항**
  * 활동 요약·상위 구독·댓글·좋아요·조회 집계 구현 및 서비스화
  * 게시글 저장 최적화 모드(중복 URL 필터링·배치 처리) 및 배치 후 알림 집계 전송
  * 트랜잭션 이후 안전한 동기화/알림 호출 처리, 알림 API 인증 기반 변경

* **데이터**
  * 댓글 스냅샷에 사용자 닉네임 추가
  * 조회·댓글 카운트 필드명 간소화 및 원시 정수 타입 변경
  * 알림 응답에 resourceName 추가 및 도메인 시간/확인 필드 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->