### PR TITLE
[fix] 활동내역/알림 기능 복구

### DIFF
--- a/monew/src/main/java/com/spring/monew/activity/domain/ActivityArticleViewDoc.java
+++ b/monew/src/main/java/com/spring/monew/activity/domain/ActivityArticleViewDoc.java
@@ -17,8 +17,8 @@ import org.springframework.data.mongodb.core.mapping.Field;
 @AllArgsConstructor
 @Document("activity_article_views")
 @CompoundIndexes({
-    @CompoundIndex(name = "uk_view_user_article", def = "{'userId': 1, 'articleId': 1}", unique = true),
-    @CompoundIndex(name = "ix_view_user_lastViewed", def = "{'userId': 1, 'lastViewedAt': -1}")
+    @CompoundIndex(name = "uk_view_user_article", def = "{'user_id': 1, 'article_id': 1}", unique = true),
+    @CompoundIndex(name = "ix_view_user_lastViewed", def = "{'user_id': 1, 'last_viewed_at': -1}")
 })
 public class ActivityArticleViewDoc {
     @Id

--- a/monew/src/main/java/com/spring/monew/activity/domain/ActivityArticleViewDoc.java
+++ b/monew/src/main/java/com/spring/monew/activity/domain/ActivityArticleViewDoc.java
@@ -10,26 +10,39 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Document("activity_article_views")
 @CompoundIndexes({
-        @CompoundIndex(name = "uk_view_user_article", def = "{'userId': 1, 'articleId': 1}", unique = true),
-        @CompoundIndex(name = "ix_view_user_lastViewed", def = "{'userId': 1, 'lastViewedAt': -1}")
+    @CompoundIndex(name = "uk_view_user_article", def = "{'userId': 1, 'articleId': 1}", unique = true),
+    @CompoundIndex(name = "ix_view_user_lastViewed", def = "{'userId': 1, 'lastViewedAt': -1}")
 })
 public class ActivityArticleViewDoc {
-    @Id private String id;        // viewEventId (최초 삽입 시)
+    @Id
+    private String id; // viewEventId
+    @Field("user_id")
     private UUID userId;
+    @Field("article_id")
     private UUID articleId;
+    @Field("source")
     private ArticleSource source;
+    @Field("source_url")
     private String sourceUrl;
+    @Field("title")
     private String title;
+    @Field("summary")
     private String summary;
+    @Field("comment_count")
     private Long commentCount;
+    @Field("view_count")
     private Long viewCount;
+    @Field("publish_date")
     private Instant publishDate;
-    private Instant createdAt;    // 최초 본 시각
-    private Instant lastViewedAt; // 최근 본 시각
+    @Field("created_at")
+    private Instant createdAt;
+    @Field("last_viewed_at")
+    private Instant lastViewedAt;
 }

--- a/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
+++ b/monew/src/main/java/com/spring/monew/activity/repository/impl/UserActivityQueryRepositoryImpl.java
@@ -9,15 +9,20 @@ import com.spring.monew.activity.domain.ActivityCommentDoc;
 import com.spring.monew.activity.domain.ActivityCommentLikeDoc;
 import com.spring.monew.activity.domain.UserInterestSubscriptionDoc;
 import com.spring.monew.activity.repository.UserActivityQueryRepository;
+import com.spring.monew.article.domain.Article;
+import com.spring.monew.article.repository.ArticleRepository;
 import com.spring.monew.articleview.controller.dto.response.ArticleViewDto;
 import com.spring.monew.subscription.controller.dto.response.SubscriptionDto;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Sort;
@@ -33,6 +38,7 @@ public class UserActivityQueryRepositoryImpl implements UserActivityQueryReposit
 
   private final MongoTemplate mongo;
   private final JdbcTemplate jdbc;
+  private final ArticleRepository articleRepository;
 
   @Override
   public Optional<UserSummary> findUserSummary(UUID userId) {
@@ -147,16 +153,32 @@ public class UserActivityQueryRepositoryImpl implements UserActivityQueryReposit
     q.limit(topN);
 
     List<ActivityArticleViewDoc> docs = mongo.find(q, ActivityArticleViewDoc.class);
-    List<ArticleViewDto> out = new ArrayList<>(docs.size());
+    if (docs.isEmpty()) return List.of();
 
+    List<UUID> articleIds = docs.stream()
+        .map(ActivityArticleViewDoc::getArticleId)
+        .distinct()
+        .toList();
+
+    Map<UUID, Long> latestCc = articleRepository.findAllById(articleIds).stream()
+        .collect(Collectors.toMap(
+            Article::getId,
+            a -> a.getCommentCount() == 0 ? 0L : a.getCommentCount()
+        ));
+
+    List<ArticleViewDto> out = new ArrayList<>(docs.size());
     for (ActivityArticleViewDoc d : docs) {
-      long cc = d.getCommentCount() == null ? 0L : d.getCommentCount();
+      // ★ 변경: 댓글수는 RDB 최신값 우선, 없으면 Mongo 값 사용
+      long cc = latestCc.getOrDefault(
+          d.getArticleId(),
+          d.getCommentCount() == null ? 0L : d.getCommentCount()
+      );
       long vc = d.getViewCount() == null ? 0L : d.getViewCount();
 
       out.add(new ArticleViewDto(
           UUID.fromString(d.getId()),
           d.getUserId(),
-          d.getLastViewedAt(),   // 최근 조회 시각
+          d.getLastViewedAt(),
           d.getArticleId(),
           d.getSource(),
           d.getSourceUrl(),

--- a/monew/src/main/java/com/spring/monew/batch/config/NewsCollectionJobConfig.java
+++ b/monew/src/main/java/com/spring/monew/batch/config/NewsCollectionJobConfig.java
@@ -1,11 +1,13 @@
 package com.spring.monew.batch.config;
 
+import com.spring.monew.batch.listener.ArticleNotificationListener;
 import com.spring.monew.batch.processor.ArticleCandidateProcessor;
 import com.spring.monew.batch.reader.ArticleCandidateReader;
 import com.spring.monew.batch.writer.ArticleWriter;
 import com.spring.monew.article.client.dto.ArticleCandidate;
 import com.spring.monew.article.domain.Article;
 import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.ItemWriteListener;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
@@ -26,6 +28,7 @@ public class NewsCollectionJobConfig {
     private final ArticleCandidateProcessor articleCandidateProcessor;
     private final ArticleWriter articleWriter;
     private final BatchSkipListener batchSkipListener;
+    private final ArticleNotificationListener articleNotificationListener;
 
     @Bean
     public Job newsCollectionJob() {
@@ -44,6 +47,8 @@ public class NewsCollectionJobConfig {
                 .listener(articleCandidateReader)
                 .listener(articleCandidateProcessor)
                 .listener(batchSkipListener)
+                .listener((ItemWriteListener<? super Article>) articleNotificationListener)
+                .listener((org.springframework.batch.core.StepExecutionListener) articleNotificationListener)
                 .faultTolerant()
                 .skip(DataIntegrityViolationException.class)
                 .skipLimit(100)


### PR DESCRIPTION
## Issues
- closed #88

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

- [x] 최근 본 기사가 출력이 안되는 문제를 해결했습니다
- [x] 관심사 알림 기능을 복구했습니다
- [x] 최근 활동내역 댓글 카운트 기능을 수정했습니다

## 📷 Screenshot

## 📚 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 게시물 댓글 수 집계 로직 개선 — 관계형 DB의 최신 카운트를 우선 반영해 더 정확한 정보를 제공합니다.

* **시스템 강화**
  * 저장 필드명 표준화(스네이크케이스)로 데이터 일관성과 조회 안정성이 향상되었습니다.
  * 뉴스 수집 배치에 기사 알림 리스너가 추가되어 처리 시점에 알림/후속작업이 활성화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->