### PR TITLE
[feat] 뉴스 기사 백업 및 복구

### DIFF
--- a/monew/build.gradle
+++ b/monew/build.gradle
@@ -85,7 +85,7 @@ dependencies {
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
 	// AWS SDK for S3
-	implementation platform('software.amazon.awssdk:bom:2.29.32')
+	implementation platform('software.amazon.awssdk:bom:2.34.0')
 	implementation 'software.amazon.awssdk:s3'
 }
 

--- a/monew/build.gradle
+++ b/monew/build.gradle
@@ -83,6 +83,10 @@ dependencies {
 	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+	// AWS SDK for S3
+	implementation platform('software.amazon.awssdk:bom:2.29.32')
+	implementation 'software.amazon.awssdk:s3'
 }
 
 tasks.named('test') {

--- a/monew/src/main/java/com/spring/monew/article/controller/ArticleController.java
+++ b/monew/src/main/java/com/spring/monew/article/controller/ArticleController.java
@@ -31,14 +31,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/articles")
 @RequiredArgsConstructor
 @Validated
-@Tag(name = "기사", description = "기사 목록 조회 및 검색 API")
+@Tag(name = "뉴스 기사 관리", description = "기사 목록 조회 및 검색 API")
 public class ArticleController {
 
   private final ArticleService articleService;
   private final RequestUserExtractor userExtractor;
 
   @GetMapping
-  @Operation(summary = "기사 목록 조회", description = "필터, 검색, 정렬 기능을 지원하는 페이지네이션 기사 목록 조회")
+  @Operation(summary = "뉴스 기사 목록 조회", description = "조건에 맞는 뉴스 기사 목록을 조회합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "조회 성공"),
+          @ApiResponse(responseCode = "400", description = "잘못된 요청 (정렬 기준 오류, 페이지네이션 파라미터 오류 등)"),
+          @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
   public CursorPageResponseArticleDto articleList(
       @Parameter(description = "검색어(제목, 요약)")
       @RequestParam(required = false) String keyword,
@@ -67,9 +72,9 @@ public class ArticleController {
       @RequestParam(required = false) String cursor,
 
       @Parameter(description = "커서 페이지 크기", required = true)
-      @RequestParam(required = true) 
-      @Min(1) 
-      @Max(100) 
+      @RequestParam(required = true)
+      @Min(1)
+      @Max(100)
       int limit,
 
       Principal principal
@@ -93,8 +98,13 @@ public class ArticleController {
   @GetMapping("/{articleId}")
   @Operation(
       summary = "뉴스 기사 단건 조회",
-      description = "뉴스 기사 ID를 사용하여 특정 기사의 상세 정보를 조회합니다. 조회 시 자동으로 조회수가 증가하며, 같은 사용자의 중복 조회는 24시간 동안 1회만 카운트됩니다."
+          description = "뉴스 기사 ID로 뉴스 기사 단건을 조회합니다."
   )
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "조회 성공"),
+          @ApiResponse(responseCode = "404", description = "뉴스 기사 정보 없음"),
+          @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
   public ArticleDto articleDetails(
       @Parameter(description = "뉴스 기사 ID", required = true)
       @PathVariable UUID articleId,
@@ -106,7 +116,11 @@ public class ArticleController {
   }
 
   @GetMapping("/sources")
-  @Operation(summary = "기사 출처 목록 조회", description = "뉴스 기사 출처 enum 값 목록 반환")
+  @Operation(summary = "출처 목록 조회", description = "출처 목록을 조회합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "조회 성공"),
+          @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
   public List<String> articleSourceList() {
     return articleService.getSources();
   }

--- a/monew/src/main/java/com/spring/monew/article/controller/ArticleController.java
+++ b/monew/src/main/java/com/spring/monew/article/controller/ArticleController.java
@@ -1,9 +1,9 @@
 package com.spring.monew.article.controller;
 
 import com.spring.monew.article.controller.dto.response.ArticleDto;
+import com.spring.monew.article.controller.dto.response.ArticleRestoreResultDto;
 import com.spring.monew.article.controller.dto.response.CursorPageResponseArticleDto;
 import com.spring.monew.article.service.ArticleService;
-import com.spring.monew.auth.config.HeaderUserAuthentication;
 import com.spring.monew.common.util.RequestUserExtractor;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -15,11 +15,16 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -104,5 +109,48 @@ public class ArticleController {
   @Operation(summary = "기사 출처 목록 조회", description = "뉴스 기사 출처 enum 값 목록 반환")
   public List<String> articleSourceList() {
     return articleService.getSources();
+  }
+
+  @DeleteMapping("/{articleId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(summary = "뉴스 기사 삭제", description = "특정 기사를 소프트 삭제합니다 (논리 삭제)")
+  public void softDeleteArticle(
+      @Parameter(description = "뉴스 기사 ID", required = true)
+      @PathVariable UUID articleId,
+      Principal principal
+  ) {
+    UUID userId = userExtractor.extractUserId(principal);
+    articleService.softDeleteArticle(articleId, userId);
+  }
+
+  @DeleteMapping("/{articleId}/hard")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(summary = "뉴스 기사 영구 삭제", description = "특정 기사 및 관련된 모든 데이터(댓글, 좋아요, 조회수)를 데이터베이스에서 완전히 삭제합니다")
+  public void hardDeleteArticle(
+      @Parameter(description = "뉴스 기사 ID", required = true)
+      @PathVariable UUID articleId,
+      Principal principal
+  ) {
+    UUID userId = userExtractor.extractUserId(principal);
+    articleService.hardDeleteArticle(articleId, userId);
+  }
+
+  @GetMapping("/restore")
+  @Operation(
+      summary = "백업에서 기사 복원",
+      description = "S3 백업에서 지정된 날짜 범위의 누락된 기사를 복원합니다. 최대 31일 범위까지 가능합니다."
+  )
+  public ResponseEntity<ArticleRestoreResultDto> restoreArticles(
+      @Parameter(description = "시작 날짜", required = true)
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+      
+      @Parameter(description = "종료 날짜", required = true)
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
+      
+      Principal principal
+  ) {
+    UUID userId = userExtractor.extractUserId(principal);
+    ArticleRestoreResultDto result = articleService.restoreArticlesFromBackup(from, to, userId);
+    return ResponseEntity.ok(result);
   }
 }

--- a/monew/src/main/java/com/spring/monew/article/domain/Article.java
+++ b/monew/src/main/java/com/spring/monew/article/domain/Article.java
@@ -92,6 +92,7 @@ public class Article {
       article.viewCount = viewCount;
       article.commentCount = commentCount;
       article.createdAt = createdAt;
+      article.updatedAt = createdAt;
       return article;
     }
 

--- a/monew/src/main/java/com/spring/monew/article/domain/Article.java
+++ b/monew/src/main/java/com/spring/monew/article/domain/Article.java
@@ -83,6 +83,18 @@ public class Article {
         return new Article(interest, source, sourceUrl, title, publishDate, summary);
     }
 
+    public static Article restore(UUID id, Interest interest, ArticleSource source,
+                                  String sourceUrl, String title, Instant publishDate,
+                                  String summary, long viewCount, long commentCount,
+                                  Instant createdAt) {
+      Article article = new Article(interest, source, sourceUrl, title, publishDate, summary);
+      article.id = id;
+      article.viewCount = viewCount;
+      article.commentCount = commentCount;
+      article.createdAt = createdAt;
+      return article;
+    }
+
     public void incrementViewCount() {
         this.viewCount++;
     }
@@ -98,7 +110,6 @@ public class Article {
     }
     
     
-    // 테스트용
     @TestOnly
     public Article(
         UUID id,

--- a/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
+++ b/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
@@ -2,9 +2,11 @@ package com.spring.monew.article.repository;
 
 import com.spring.monew.article.domain.Article;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,4 +14,17 @@ public interface ArticleRepository extends JpaRepository<Article, UUID>, Article
 
   @Query("select a.sourceUrl from Article a where a.sourceUrl in :urls")
   Set<String> findExistingSourceUrls(@Param("urls") Collection<String> urls);
+
+  @Modifying(clearAutomatically = true)
+  @Query(value = "DELETE FROM articles WHERE id = :articleId", nativeQuery = true)
+  void hardDelete(@Param("articleId") UUID articleId);
+
+  @Query(value = "SELECT EXISTS(SELECT 1 FROM articles WHERE id = :articleId)", nativeQuery = true)
+  boolean existsIncludingDeleted(@Param("articleId") UUID articleId);
+
+  @Query(value = "SELECT * FROM articles WHERE id = :articleId", nativeQuery = true)
+  Optional<Article> findIncludingDeleted(@Param("articleId") UUID articleId);
+
+  @Query("SELECT a.sourceUrl FROM Article a")
+  Set<String> findAllSourceUrls();
 }

--- a/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
+++ b/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
@@ -24,7 +24,7 @@ public interface ArticleRepository extends JpaRepository<Article, UUID>, Article
   @Query(value = "SELECT EXISTS(SELECT 1 FROM articles WHERE id = :articleId)", nativeQuery = true)
   boolean existsIncludingDeleted(@Param("articleId") UUID articleId);
 
-  @Query(value = "SELECT * FROM articles WHERE id = :articleId", nativeQuery = true)
+  @Query(value = "SELECT * FROM articles WHERE id = :articleId AND is_deleted = true", nativeQuery = true)
   Optional<Article> findIncludingDeleted(@Param("articleId") UUID articleId);
 
   @Query("SELECT a.sourceUrl FROM Article a")

--- a/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
+++ b/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
@@ -38,5 +38,14 @@ public interface ArticleRepository extends JpaRepository<Article, UUID>, Article
     """, nativeQuery = true)
   List<UUID> findSoftDeletedBefore(@Param("threshold") Instant threshold);
 
+  @Query(value = """
+    SELECT id FROM articles
+    WHERE is_deleted = true
+      AND deleted_at IS NOT NULL
+      AND deleted_at >= :startTime
+      AND deleted_at <= :endTime
+    """, nativeQuery = true)
+  List<UUID> findSoftDeletedBetween(@Param("startTime") Instant startTime, @Param("endTime") Instant endTime);
+
   List<Article> findAllByInterestId(UUID interestId);
 }

--- a/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
+++ b/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
@@ -37,4 +37,6 @@ public interface ArticleRepository extends JpaRepository<Article, UUID>, Article
       AND deleted_at < :threshold
     """, nativeQuery = true)
   List<UUID> findSoftDeletedBefore(@Param("threshold") Instant threshold);
+
+  List<Article> findAllByInterestId(UUID interestId);
 }

--- a/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
+++ b/monew/src/main/java/com/spring/monew/article/repository/ArticleRepository.java
@@ -1,7 +1,9 @@
 package com.spring.monew.article.repository;
 
 import com.spring.monew.article.domain.Article;
+import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -27,4 +29,12 @@ public interface ArticleRepository extends JpaRepository<Article, UUID>, Article
 
   @Query("SELECT a.sourceUrl FROM Article a")
   Set<String> findAllSourceUrls();
+
+  @Query(value = """
+    SELECT id FROM articles
+    WHERE is_deleted = true
+      AND deleted_at IS NOT NULL
+      AND deleted_at < :threshold
+    """, nativeQuery = true)
+  List<UUID> findSoftDeletedBefore(@Param("threshold") Instant threshold);
 }

--- a/monew/src/main/java/com/spring/monew/article/service/ArticleService.java
+++ b/monew/src/main/java/com/spring/monew/article/service/ArticleService.java
@@ -1,6 +1,7 @@
 package com.spring.monew.article.service;
 
 import com.spring.monew.article.controller.dto.response.ArticleDto;
+import com.spring.monew.article.controller.dto.response.ArticleRestoreResultDto;
 import com.spring.monew.article.controller.dto.response.CursorPageResponseArticleDto;
 import java.time.Instant;
 import java.util.List;
@@ -24,4 +25,10 @@ public interface ArticleService {
   List<String> getSources();
 
   ArticleDto getArticle(UUID articleId, UUID userId);
+
+  void softDeleteArticle(UUID articleId, UUID userId);
+
+  void hardDeleteArticle(UUID articleId, UUID userId);
+
+  ArticleRestoreResultDto restoreArticlesFromBackup(Instant fromDate, Instant toDate, UUID userId);
 }

--- a/monew/src/main/java/com/spring/monew/article/service/impl/ArticleServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/article/service/impl/ArticleServiceImpl.java
@@ -159,7 +159,7 @@ public class ArticleServiceImpl implements ArticleService {
   }
 
   @Override
-  @Transactional(isolation = Isolation.SERIALIZABLE)
+  @Transactional(isolation = Isolation.READ_COMMITTED)
   public void hardDeleteArticle(UUID articleId, UUID userId) {
     String requestId = MDC.get("requestId");
     try {
@@ -199,6 +199,7 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     List<UUID> restoredArticleIds = new ArrayList<>();
+    List<String> failedDates = new ArrayList<>();
     LocalDate currentDate = fromDate.atZone(ZoneOffset.UTC).toLocalDate();
     LocalDate endDate = toDate.atZone(ZoneOffset.UTC).toLocalDate();
 
@@ -213,11 +214,16 @@ public class ArticleServiceImpl implements ArticleService {
         }
       } catch (Exception e) {
         log.warn("날짜 {}의 백업 복원 중 오류 발생: {}", currentDate, e.getMessage());
+        failedDates.add(currentDate.toString());
       }
       
       currentDate = currentDate.plusDays(1);
     }
 
+    if (!failedDates.isEmpty()) {
+      log.warn("복원 실패한 날짜: {}", String.join(", ", failedDates));
+    }
+    
     log.info("복원 완료: {} 개의 기사 복원됨", restoredArticleIds.size());
     auditLogger.logRestore(fromDate, toDate, restoredArticleIds.size(), userId, requestId);
     return new ArticleRestoreResultDto(Instant.now(), restoredArticleIds, restoredArticleIds.size());
@@ -246,9 +252,13 @@ public class ArticleServiceImpl implements ArticleService {
       return List.of();
     }
 
-    Set<String> existingUrls = articleRepository.findAllSourceUrls();
-    log.info("[복원] 현재 DB에 존재하는 기사 URL 개수: {}", existingUrls.size());
-    log.info("[복원] 백업 파일의 기사 개수: {}", backupDataList.size());
+    List<String> backupUrls = backupDataList.stream()
+        .map(data -> (String) data.get("sourceUrl"))
+        .filter(url -> url != null)
+        .toList();
+
+    Set<String> existingUrls = articleRepository.findExistingSourceUrls(backupUrls);
+    log.info("[복원] 백업 파일의 기사 개수: {}, DB에 존재하는 URL 개수: {}", backupUrls.size(), existingUrls.size());
     
     List<Map<String, Object>> missingArticles = new ArrayList<>();
 

--- a/monew/src/main/java/com/spring/monew/article/service/impl/ArticleServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/article/service/impl/ArticleServiceImpl.java
@@ -24,6 +24,8 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -164,8 +166,6 @@ public class ArticleServiceImpl implements ArticleService {
       Article article = articleRepository.findIncludingDeleted(articleId)
           .orElseThrow(() -> new ArticleNotFoundException(articleId));
 
-      // Backup handled by scheduled batch job (ArticleBackupScheduler)
-
       int commentsDeleted = commentRepository.countByArticleId(articleId);
       int viewsDeleted = articleViewRepository.countByArticleId(articleId);
 
@@ -233,7 +233,7 @@ public class ArticleServiceImpl implements ArticleService {
         backups.add(backupMap);
       }
       
-      log.debug("Found {} backups for date: {}", backups.size(), date);
+      log.info("[복원] {} 날짜의 백업 파일에서 {}개 기사 발견", date, backups.size());
       return backups;
     } catch (Exception e) {
       log.warn("백업 검색 실패 for date {}: {}", date, e.getMessage());
@@ -247,17 +247,27 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     Set<String> existingUrls = articleRepository.findAllSourceUrls();
+    log.info("[복원] 현재 DB에 존재하는 기사 URL 개수: {}", existingUrls.size());
+    log.info("[복원] 백업 파일의 기사 개수: {}", backupDataList.size());
+    
     List<Map<String, Object>> missingArticles = new ArrayList<>();
 
     for (Map<String, Object> backupData : backupDataList) {
       String sourceUrl = (String) backupData.get("sourceUrl");
       if (sourceUrl != null && !existingUrls.contains(sourceUrl)) {
         missingArticles.add(backupData);
+        log.debug("[복원] 복원 대상 기사: sourceUrl={}", sourceUrl);
+      } else {
+        log.debug("[복원] 이미 존재하는 기사 (스킵): sourceUrl={}", sourceUrl);
       }
     }
 
+    log.info("[복원] 복원 대상 기사 개수: {} (백업: {}, 중복: {})", 
+        missingArticles.size(), backupDataList.size(), backupDataList.size() - missingArticles.size());
+
     return missingArticles;
   }
+
 
   private Article restoreArticle(Map<String, Object> backupData) {
     try {
@@ -278,7 +288,17 @@ public class ArticleServiceImpl implements ArticleService {
       long commentCount = commentCountNum != null ? commentCountNum.longValue() : 0L;
 
       Interest interest = interestRepository.findById(interestId)
-          .orElseGet(() -> getDefaultInterest());
+          .or(() -> {
+            log.info("활성 Interest를 찾을 수 없음. 삭제된 Interest를 확인합니다: interestId={}", interestId);
+            return interestRepository.findIncludingDeleted(interestId)
+                .map(deletedInterest -> {
+                  deletedInterest.undelete();
+                  Interest restored = interestRepository.save(deletedInterest);
+                  log.info("Interest 복원 완료: id={}, name={}", restored.getId(), restored.getName());
+                  return restored;
+                });
+          })
+          .orElseGet(() -> getOrCreateDefaultInterest());
 
       Article article = Article.restore(
           articleId,
@@ -316,9 +336,24 @@ public class ArticleServiceImpl implements ArticleService {
     return Instant.now();
   }
 
-  private Interest getDefaultInterest() {
+  private Interest getOrCreateDefaultInterest() {
     return interestRepository.findAll().stream()
         .findFirst()
-        .orElseThrow(() -> new IllegalStateException("최소 하나의 Interest가 존재해야 합니다"));
+        .orElseGet(() -> {
+          log.warn("활성화된 Interest가 없습니다. 삭제된 Interest를 복원합니다.");
+          
+          Optional<Interest> deletedInterest = interestRepository.findFirstDeleted();
+          if (deletedInterest.isPresent()) {
+            Interest interest = deletedInterest.get();
+            interest.undelete();
+            Interest restored = interestRepository.save(interest);
+            log.info("삭제된 Interest 복원 완료: id={}, name={}", restored.getId(), restored.getName());
+            return restored;
+          }
+          
+          log.warn("삭제된 Interest도 없어서 기본 Interest를 생성합니다");
+          Interest defaultInterest = new Interest("복원됨", List.of("복원"));
+          return interestRepository.save(defaultInterest);
+        });
   }
 }

--- a/monew/src/main/java/com/spring/monew/article/service/impl/ArticleServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/article/service/impl/ArticleServiceImpl.java
@@ -1,20 +1,39 @@
 package com.spring.monew.article.service.impl;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spring.monew.article.controller.dto.response.ArticleDto;
+import com.spring.monew.article.controller.dto.response.ArticleRestoreResultDto;
 import com.spring.monew.article.controller.dto.response.CursorPageResponseArticleDto;
 import com.spring.monew.article.domain.Article;
 import com.spring.monew.article.domain.ArticleSource;
 import com.spring.monew.article.exception.ArticleNotFoundException;
 import com.spring.monew.article.repository.ArticleRepository;
 import com.spring.monew.article.service.ArticleService;
+import com.spring.monew.backup.dto.ArticleBackupDto;
+import com.spring.monew.backup.service.S3BackupService;
+import com.spring.monew.common.logging.AuditLogger;
 import com.spring.monew.articleview.repository.ArticleViewRepository;
+import com.spring.monew.comment.repository.CommentRepository;
+import com.spring.monew.interest.domain.Interest;
+import com.spring.monew.interest.repository.InterestRepository;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
+import org.slf4j.MDC;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -22,6 +41,11 @@ public class ArticleServiceImpl implements ArticleService {
 
   private final ArticleRepository articleRepository;
   private final ArticleViewRepository articleViewRepository;
+  private final CommentRepository commentRepository;
+  private final S3BackupService s3BackupService;
+  private final InterestRepository interestRepository;
+  private final ObjectMapper objectMapper;
+  private final AuditLogger auditLogger;
 
   @Override
   public CursorPageResponseArticleDto getArticles(
@@ -83,6 +107,7 @@ public class ArticleServiceImpl implements ArticleService {
         userId
     );
   }
+  
   @Override
   public List<String> getSources() {
     return java.util.Arrays.stream(ArticleSource.values())
@@ -114,5 +139,186 @@ public class ArticleServiceImpl implements ArticleService {
         article.getViewCount(),
         viewedByMe
     );
+  }
+
+  @Override
+  @Transactional
+  public void softDeleteArticle(UUID articleId, UUID userId) {
+    String requestId = MDC.get("requestId");
+    try {
+      Article article = articleRepository.findById(articleId)
+          .orElseThrow(() -> new ArticleNotFoundException(articleId));
+      articleRepository.delete(article);
+      auditLogger.logSoftDelete(articleId, userId, requestId);
+    } catch (ArticleNotFoundException e) {
+      auditLogger.logSoftDeleteFailure(articleId, userId, requestId, e.getMessage());
+      throw e;
+    }
+  }
+
+  @Override
+  @Transactional(isolation = Isolation.SERIALIZABLE)
+  public void hardDeleteArticle(UUID articleId, UUID userId) {
+    String requestId = MDC.get("requestId");
+    try {
+      Article article = articleRepository.findIncludingDeleted(articleId)
+          .orElseThrow(() -> new ArticleNotFoundException(articleId));
+
+      // Backup handled by scheduled batch job (ArticleBackupScheduler)
+
+      int commentsDeleted = commentRepository.countByArticleId(articleId);
+      int viewsDeleted = articleViewRepository.countByArticleId(articleId);
+
+      commentRepository.deleteCommentLikesByArticleId(articleId);
+      commentRepository.deleteByArticleId(articleId);
+      articleViewRepository.deleteByArticleId(articleId);
+      articleRepository.hardDelete(articleId);
+
+      auditLogger.logHardDelete(articleId, userId, requestId, commentsDeleted, viewsDeleted);
+    } catch (ArticleNotFoundException e) {
+      auditLogger.logHardDeleteFailure(articleId, userId, requestId, e.getMessage());
+      throw e;
+    }
+  }
+
+  @Override
+  @Transactional
+  public ArticleRestoreResultDto restoreArticlesFromBackup(Instant fromDate, Instant toDate, UUID userId) {
+    String requestId = MDC.get("requestId");
+    if (fromDate == null || toDate == null) {
+      throw new IllegalArgumentException("시작 날짜와 종료 날짜는 필수입니다");
+    }
+
+    if (fromDate.isAfter(toDate)) {
+      throw new IllegalArgumentException("시작 날짜는 종료 날짜보다 이전이어야 합니다");
+    }
+
+    Duration duration = Duration.between(fromDate, toDate);
+    if (duration.toDays() > 31) {
+      throw new IllegalArgumentException("날짜 범위는 최대 31일까지만 가능합니다");
+    }
+
+    List<UUID> restoredArticleIds = new ArrayList<>();
+    LocalDate currentDate = fromDate.atZone(ZoneOffset.UTC).toLocalDate();
+    LocalDate endDate = toDate.atZone(ZoneOffset.UTC).toLocalDate();
+
+    while (!currentDate.isAfter(endDate)) {
+      try {
+        List<Map<String, Object>> backupDataList = findBackupsForDate(currentDate);
+        List<Map<String, Object>> missingArticles = findMissingArticles(backupDataList);
+        
+        for (Map<String, Object> backupData : missingArticles) {
+          Article restored = restoreArticle(backupData);
+          restoredArticleIds.add(restored.getId());
+        }
+      } catch (Exception e) {
+        log.warn("날짜 {}의 백업 복원 중 오류 발생: {}", currentDate, e.getMessage());
+      }
+      
+      currentDate = currentDate.plusDays(1);
+    }
+
+    log.info("복원 완료: {} 개의 기사 복원됨", restoredArticleIds.size());
+    auditLogger.logRestore(fromDate, toDate, restoredArticleIds.size(), userId, requestId);
+    return new ArticleRestoreResultDto(Instant.now(), restoredArticleIds, restoredArticleIds.size());
+  }
+
+  private List<Map<String, Object>> findBackupsForDate(LocalDate date) {
+    try {
+      List<ArticleBackupDto> backupDtos = s3BackupService.downloadBackup(date);
+      
+      List<Map<String, Object>> backups = new ArrayList<>();
+      for (ArticleBackupDto dto : backupDtos) {
+        Map<String, Object> backupMap = objectMapper.convertValue(dto, new TypeReference<Map<String, Object>>() {});
+        backups.add(backupMap);
+      }
+      
+      log.debug("Found {} backups for date: {}", backups.size(), date);
+      return backups;
+    } catch (Exception e) {
+      log.warn("백업 검색 실패 for date {}: {}", date, e.getMessage());
+      return new ArrayList<>();
+    }
+  }
+
+  private List<Map<String, Object>> findMissingArticles(List<Map<String, Object>> backupDataList) {
+    if (backupDataList.isEmpty()) {
+      return List.of();
+    }
+
+    Set<String> existingUrls = articleRepository.findAllSourceUrls();
+    List<Map<String, Object>> missingArticles = new ArrayList<>();
+
+    for (Map<String, Object> backupData : backupDataList) {
+      String sourceUrl = (String) backupData.get("sourceUrl");
+      if (sourceUrl != null && !existingUrls.contains(sourceUrl)) {
+        missingArticles.add(backupData);
+      }
+    }
+
+    return missingArticles;
+  }
+
+  private Article restoreArticle(Map<String, Object> backupData) {
+    try {
+      UUID articleId = UUID.fromString((String) backupData.get("id"));
+      UUID interestId = UUID.fromString((String) backupData.get("interestId"));
+      String source = (String) backupData.get("source");
+      String sourceUrl = (String) backupData.get("sourceUrl");
+      String title = (String) backupData.get("title");
+      String summary = (String) backupData.get("summary");
+      
+      Instant publishDate = parseInstant(backupData.get("publishDate"));
+      Instant createdAt = parseInstant(backupData.get("createdAt"));
+      
+      Number viewCountNum = (Number) backupData.get("viewCount");
+      Number commentCountNum = (Number) backupData.get("commentCount");
+      
+      long viewCount = viewCountNum != null ? viewCountNum.longValue() : 0L;
+      long commentCount = commentCountNum != null ? commentCountNum.longValue() : 0L;
+
+      Interest interest = interestRepository.findById(interestId)
+          .orElseGet(() -> getDefaultInterest());
+
+      Article article = Article.restore(
+          articleId,
+          interest,
+          ArticleSource.valueOf(source),
+          sourceUrl,
+          title,
+          publishDate,
+          summary,
+          viewCount,
+          commentCount,
+          createdAt
+      );
+
+      Article saved = articleRepository.save(article);
+      log.info("기사 복원 완료: articleId={}, sourceUrl={}", articleId, sourceUrl);
+      
+      return saved;
+    } catch (Exception e) {
+      log.error("기사 복원 실패: {}", backupData, e);
+      throw new RuntimeException("기사 복원 실패", e);
+    }
+  }
+
+  private Instant parseInstant(Object value) {
+    if (value == null) {
+      return Instant.now();
+    }
+    if (value instanceof String) {
+      return Instant.parse((String) value);
+    }
+    if (value instanceof Number) {
+      return Instant.ofEpochMilli(((Number) value).longValue());
+    }
+    return Instant.now();
+  }
+
+  private Interest getDefaultInterest() {
+    return interestRepository.findAll().stream()
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("최소 하나의 Interest가 존재해야 합니다"));
   }
 }

--- a/monew/src/main/java/com/spring/monew/articleview/controller/Test.java
+++ b/monew/src/main/java/com/spring/monew/articleview/controller/Test.java
@@ -1,5 +1,0 @@
-package com.spring.monew.articleview.controller;
-
-public class Test {
-
-}

--- a/monew/src/main/java/com/spring/monew/articleview/repository/ArticleViewRepository.java
+++ b/monew/src/main/java/com/spring/monew/articleview/repository/ArticleViewRepository.java
@@ -2,6 +2,9 @@ package com.spring.monew.articleview.repository;
 
 import com.spring.monew.articleview.domain.ArticleView;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -19,4 +22,11 @@ public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> 
         UUID userId,
         Instant createdAtAfter
     );
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = "DELETE FROM article_views WHERE article_id = :articleId", nativeQuery = true)
+    void deleteByArticleId(@Param("articleId") UUID articleId);
+
+    @Query(value = "SELECT COUNT(*) FROM article_views WHERE article_id = :articleId", nativeQuery = true)
+    int countByArticleId(@Param("articleId") UUID articleId);
 }

--- a/monew/src/main/java/com/spring/monew/auth/config/SecurityConfig.java
+++ b/monew/src/main/java/com/spring/monew/auth/config/SecurityConfig.java
@@ -23,28 +23,32 @@ public class SecurityConfig {
   private final RequestIdFilter requestIdFilter;
 
   @Value("${monitoring.prometheus.allow-ip}")
-  private String prometheusAllowIp;
+  private String prometheusAllowIp;// yml 속성 주입 (기본값은 localhost)
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
-        .csrf(AbstractHttpConfigurer::disable)
+        .csrf(AbstractHttpConfigurer::disable)// CSRF 보안 비활성화 (개발용)
 
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/actuator/prometheus")
             .access((authentication, context) -> {
               String remoteAddr = context.getRequest().getRemoteAddr();
-              boolean equals = remoteAddr.equals(prometheusAllowIp);
+              boolean equals = remoteAddr.equals(prometheusAllowIp);// Prometheus IP
               return new AuthorizationDecision(equals);
             })
             .requestMatchers("/actuator/health", "/actuator/info",
-                "/actuator/loggers").permitAll()
+                "/actuator/loggers").permitAll()//Actuator 허용 (원래는 이렇게 하면 안됨)
+                //  모든 경로 허용 (개발용)
             .requestMatchers("/api/batch/**").permitAll()
             .anyRequest().permitAll()
         )
+            // 헤더에 담긴 userId를 읽어서 인증 정보를 만들어주는 필터
         .addFilterBefore(requestIdFilter, UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(headerAuthFilter, UsernamePasswordAuthenticationFilter.class);
-
+      //.requestMatchers(HttpMethod.POST, "/api/users", "/api/users/login").permitAll()
+      //  나머지 요청은 인증 필요
+      //.anyRequest().authenticated()
     return http.build();
   }
 

--- a/monew/src/main/java/com/spring/monew/auth/config/SecurityConfig.java
+++ b/monew/src/main/java/com/spring/monew/auth/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import com.spring.monew.common.filter.RequestIdFilter;
 
 @RequiredArgsConstructor
 @Configuration
@@ -19,33 +20,30 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   private final HeaderAuthFilter headerAuthFilter;
+  private final RequestIdFilter requestIdFilter;
 
   @Value("${monitoring.prometheus.allow-ip}")
-  private String prometheusAllowIp; // yml 속성 주입 (기본값은 localhost)
+  private String prometheusAllowIp;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
-        .csrf(AbstractHttpConfigurer::disable) // CSRF 보안 비활성화 (개발용)
+        .csrf(AbstractHttpConfigurer::disable)
 
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/actuator/prometheus")
             .access((authentication, context) -> {
               String remoteAddr = context.getRequest().getRemoteAddr();
-              boolean equals = remoteAddr.equals(prometheusAllowIp);// Prometheus IP
+              boolean equals = remoteAddr.equals(prometheusAllowIp);
               return new AuthorizationDecision(equals);
             })
             .requestMatchers("/actuator/health", "/actuator/info",
-                "/actuator/loggers").permitAll() //Actuator 허용 (원래는 이렇게 하면 안됨)
-            //  모든 경로 허용 (개발용)
+                "/actuator/loggers").permitAll()
             .requestMatchers("/api/batch/**").permitAll()
             .anyRequest().permitAll()
         )
-        // 헤더에 담긴 userId를 읽어서 인증 정보를 만들어주는 필터
+        .addFilterBefore(requestIdFilter, UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(headerAuthFilter, UsernamePasswordAuthenticationFilter.class);
-    //.requestMatchers(HttpMethod.POST, "/api/users", "/api/users/login").permitAll()
-    //  나머지 요청은 인증 필요
-    //.anyRequest().authenticated()
 
     return http.build();
   }

--- a/monew/src/main/java/com/spring/monew/auth/config/SecurityConfig.java
+++ b/monew/src/main/java/com/spring/monew/auth/config/SecurityConfig.java
@@ -23,12 +23,12 @@ public class SecurityConfig {
   private final RequestIdFilter requestIdFilter;
 
   @Value("${monitoring.prometheus.allow-ip}")
-  private String prometheusAllowIp;// yml 속성 주입 (기본값은 localhost)
+  private String prometheusAllowIp; // yml 속성 주입 (기본값은 localhost)
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
-        .csrf(AbstractHttpConfigurer::disable)// CSRF 보안 비활성화 (개발용)
+        .csrf(AbstractHttpConfigurer::disable) // CSRF 보안 비활성화 (개발용)
 
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/actuator/prometheus")
@@ -38,7 +38,7 @@ public class SecurityConfig {
               return new AuthorizationDecision(equals);
             })
             .requestMatchers("/actuator/health", "/actuator/info",
-                "/actuator/loggers").permitAll()//Actuator 허용 (원래는 이렇게 하면 안됨)
+                "/actuator/loggers").permitAll() //Actuator 허용 (원래는 이렇게 하면 안됨)
                 //  모든 경로 허용 (개발용)
             .requestMatchers("/api/batch/**").permitAll()
             .anyRequest().permitAll()

--- a/monew/src/main/java/com/spring/monew/backup/dto/ArticleBackupDto.java
+++ b/monew/src/main/java/com/spring/monew/backup/dto/ArticleBackupDto.java
@@ -1,0 +1,36 @@
+package com.spring.monew.backup.dto;
+
+import com.spring.monew.article.domain.Article;
+import com.spring.monew.article.domain.ArticleSource;
+import com.spring.monew.interest.domain.Interest;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ArticleBackupDto(
+    UUID id,
+    UUID interestId,
+    String source,
+    String sourceUrl,
+    String title,
+    String summary,
+    Instant publishDate,
+    long viewCount,
+    long commentCount,
+    Instant createdAt
+) {
+  public static ArticleBackupDto from(Article article) {
+    return new ArticleBackupDto(
+        article.getId(),
+        article.getInterest().getId(),
+        article.getSource().name(),
+        article.getSourceUrl(),
+        article.getTitle(),
+        article.getSummary(),
+        article.getPublishDate(),
+        article.getViewCount(),
+        article.getCommentCount(),
+        article.getCreatedAt()
+    );
+  }
+}

--- a/monew/src/main/java/com/spring/monew/backup/dto/ArticleBackupDto.java
+++ b/monew/src/main/java/com/spring/monew/backup/dto/ArticleBackupDto.java
@@ -20,6 +20,9 @@ public record ArticleBackupDto(
     Instant createdAt
 ) {
   public static ArticleBackupDto from(Article article) {
+    if (article.getInterest() == null) {
+      throw new IllegalArgumentException("Article must have an associated Interest");
+    }
     return new ArticleBackupDto(
         article.getId(),
         article.getInterest().getId(),

--- a/monew/src/main/java/com/spring/monew/backup/exception/BackupNotFoundException.java
+++ b/monew/src/main/java/com/spring/monew/backup/exception/BackupNotFoundException.java
@@ -1,0 +1,21 @@
+package com.spring.monew.backup.exception;
+
+import java.time.LocalDate;
+
+public class BackupNotFoundException extends RuntimeException {
+  private final LocalDate backupDate;
+
+  public BackupNotFoundException(LocalDate backupDate) {
+    super("Backup not found for date: " + backupDate);
+    this.backupDate = backupDate;
+  }
+
+  public BackupNotFoundException(LocalDate backupDate, Throwable cause) {
+    super("Backup not found for date: " + backupDate, cause);
+    this.backupDate = backupDate;
+  }
+
+  public LocalDate getBackupDate() {
+    return backupDate;
+  }
+}

--- a/monew/src/main/java/com/spring/monew/backup/exception/S3ServiceException.java
+++ b/monew/src/main/java/com/spring/monew/backup/exception/S3ServiceException.java
@@ -1,0 +1,11 @@
+package com.spring.monew.backup.exception;
+
+public class S3ServiceException extends RuntimeException {
+  public S3ServiceException(String message) {
+    super(message);
+  }
+
+  public S3ServiceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/monew/src/main/java/com/spring/monew/backup/service/LogBackupService.java
+++ b/monew/src/main/java/com/spring/monew/backup/service/LogBackupService.java
@@ -1,0 +1,11 @@
+package com.spring.monew.backup.service;
+
+import java.time.LocalDate;
+
+public interface LogBackupService {
+  void uploadLogFile(LocalDate logDate);
+  
+  void cleanupLocalLogs(int daysToKeep);
+  
+  boolean logFileExists(LocalDate logDate);
+}

--- a/monew/src/main/java/com/spring/monew/backup/service/S3BackupService.java
+++ b/monew/src/main/java/com/spring/monew/backup/service/S3BackupService.java
@@ -1,0 +1,15 @@
+package com.spring.monew.backup.service;
+
+import com.spring.monew.backup.dto.ArticleBackupDto;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface S3BackupService {
+  void uploadBackup(LocalDate backupDate, List<ArticleBackupDto> articles);
+
+  List<ArticleBackupDto> downloadBackup(LocalDate backupDate) throws IOException;
+
+  boolean backupExists(LocalDate backupDate);
+}

--- a/monew/src/main/java/com/spring/monew/backup/service/impl/S3BackupServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/backup/service/impl/S3BackupServiceImpl.java
@@ -1,0 +1,152 @@
+package com.spring.monew.backup.service.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.spring.monew.backup.dto.ArticleBackupDto;
+import com.spring.monew.backup.exception.BackupNotFoundException;
+import com.spring.monew.backup.exception.S3ServiceException;
+import com.spring.monew.backup.service.S3BackupService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.*;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+@Slf4j
+@Service
+public class S3BackupServiceImpl implements S3BackupService {
+
+  private final S3Client s3Client;
+  private final String bucketName;
+  private final ObjectMapper objectMapper;
+
+  private static final String KEY_PREFIX = "articles/";
+  private static final String FILE_EXTENSION = ".json.gz";
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+  public S3BackupServiceImpl(
+      S3Client s3Client,
+      @Value("${aws.s3.bucket}") String bucketName
+  ) {
+    this.s3Client = s3Client;
+    this.bucketName = bucketName;
+    this.objectMapper = new ObjectMapper();
+    this.objectMapper.registerModule(new JavaTimeModule());
+  }
+
+  @Override
+  public void uploadBackup(LocalDate backupDate, List<ArticleBackupDto> articles) {
+    String key = generateS3Key(backupDate);
+
+    try {
+      byte[] jsonBytes = objectMapper.writeValueAsBytes(articles);
+      byte[] compressedBytes = compressGzip(jsonBytes);
+
+      PutObjectRequest putRequest = PutObjectRequest.builder()
+          .bucket(bucketName)
+          .key(key)
+          .contentType("application/gzip")
+          .build();
+
+      s3Client.putObject(putRequest, RequestBody.fromBytes(compressedBytes));
+
+      log.info("S3에 백업 업로드 성공: bucket={}, key={}, articles={}", 
+          bucketName, key, articles.size());
+    } catch (IOException e) {
+      log.error("S3 백업 업로드 실패: bucket={}, key={}", bucketName, key, e);
+      throw new S3ServiceException("S3 백업 업로드 실패", e);
+    } catch (S3Exception e) {
+      log.error("백업 업로드 중 S3 오류 발생: bucket={}, key={}, statusCode={}", 
+          bucketName, key, e.statusCode(), e);
+      throw new S3ServiceException("백업 업로드 중 S3 서비스 오류", e);
+    }
+  }
+
+  @Override
+  public List<ArticleBackupDto> downloadBackup(LocalDate backupDate) throws IOException {
+    String key = generateS3Key(backupDate);
+
+    try {
+      GetObjectRequest getRequest = GetObjectRequest.builder()
+          .bucket(bucketName)
+          .key(key)
+          .build();
+
+      byte[] compressedBytes = s3Client.getObjectAsBytes(getRequest).asByteArray();
+      byte[] jsonBytes = decompressGzip(compressedBytes);
+
+      List<ArticleBackupDto> articles = objectMapper.readValue(
+          jsonBytes, 
+          new TypeReference<List<ArticleBackupDto>>() {}
+      );
+
+      log.info("S3에서 백업 다운로드 성공: bucket={}, key={}, articles={}", 
+          bucketName, key, articles.size());
+
+      return articles;
+    } catch (NoSuchKeyException e) {
+      log.error("S3에서 백업을 찾을 수 없음: bucket={}, key={}", bucketName, key);
+      throw new BackupNotFoundException(backupDate, e);
+    } catch (S3Exception e) {
+      log.error("백업 다운로드 중 S3 오류 발생: bucket={}, key={}, statusCode={}", 
+          bucketName, key, e.statusCode(), e);
+      throw new S3ServiceException("백업 다운로드 중 S3 서비스 오류", e);
+    }
+  }
+
+  @Override
+  public boolean backupExists(LocalDate backupDate) {
+    String key = generateS3Key(backupDate);
+
+    try {
+      HeadObjectRequest headRequest = HeadObjectRequest.builder()
+          .bucket(bucketName)
+          .key(key)
+          .build();
+
+      s3Client.headObject(headRequest);
+      return true;
+    } catch (NoSuchKeyException e) {
+      return false;
+    } catch (S3Exception e) {
+      log.error("백업 존재 여부 확인 중 S3 오류 발생: bucket={}, key={}, statusCode={}", 
+          bucketName, key, e.statusCode(), e);
+      return false;
+    }
+  }
+
+  private String generateS3Key(LocalDate backupDate) {
+    return KEY_PREFIX + backupDate.format(DATE_FORMATTER) + FILE_EXTENSION;
+  }
+
+  private byte[] compressGzip(byte[] data) throws IOException {
+    ByteArrayOutputStream byteStream = new ByteArrayOutputStream(data.length);
+    try (GZIPOutputStream gzipStream = new GZIPOutputStream(byteStream)) {
+      gzipStream.write(data);
+    }
+    return byteStream.toByteArray();
+  }
+
+  private byte[] decompressGzip(byte[] compressedData) throws IOException {
+    try (ByteArrayInputStream byteStream = new ByteArrayInputStream(compressedData);
+         GZIPInputStream gzipStream = new GZIPInputStream(byteStream);
+         ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+      
+      byte[] buffer = new byte[1024];
+      int len;
+      while ((len = gzipStream.read(buffer)) > 0) {
+        outputStream.write(buffer, 0, len);
+      }
+      return outputStream.toByteArray();
+    }
+  }
+}

--- a/monew/src/main/java/com/spring/monew/backup/service/impl/S3LogBackupServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/backup/service/impl/S3LogBackupServiceImpl.java
@@ -70,9 +70,6 @@ public class S3LogBackupServiceImpl implements LogBackupService {
       log.info("S3에 로그 파일 업로드 성공: bucket={}, key={}, size={} bytes", 
           logBucketName, s3Key, compressedBytes.length);
 
-      Files.delete(logFile);
-      log.info("업로드 후 로컬 로그 파일 삭제 완료: {}", logFilePathStr);
-
     } catch (IOException e) {
       log.error("로그 파일 읽기 또는 압축 실패: {}", logFilePathStr, e);
       throw new S3ServiceException("로그 파일 업로드 처리 실패", e);
@@ -80,6 +77,13 @@ public class S3LogBackupServiceImpl implements LogBackupService {
       log.error("로그 업로드 중 S3 오류 발생: bucket={}, key={}, statusCode={}", 
           logBucketName, s3Key, e.statusCode(), e);
       throw new S3ServiceException("로그 업로드 중 S3 서비스 오류", e);
+    }
+
+    try {
+      Files.delete(logFile);
+      log.info("업로드 후 로컬 로그 파일 삭제 완료: {}", logFilePathStr);
+    } catch (IOException e) {
+      log.error("업로드는 성공했으나 로컬 로그 파일 삭제 실패: {}", logFilePathStr, e);
     }
   }
 

--- a/monew/src/main/java/com/spring/monew/backup/service/impl/S3LogBackupServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/backup/service/impl/S3LogBackupServiceImpl.java
@@ -1,0 +1,147 @@
+package com.spring.monew.backup.service.impl;
+
+import com.spring.monew.backup.exception.S3ServiceException;
+import com.spring.monew.backup.service.LogBackupService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.stream.Stream;
+import java.util.zip.GZIPOutputStream;
+
+@Slf4j
+@Service
+public class S3LogBackupServiceImpl implements LogBackupService {
+
+  private final S3Client s3Client;
+  private final String logBucketName;
+  private final String logFilePath;
+  private final String logFileName;
+
+  private static final String KEY_PREFIX = "logs/";
+  private static final String FILE_EXTENSION = ".log.gz";
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+  public S3LogBackupServiceImpl(
+      S3Client s3Client,
+      @Value("${aws.s3.log-bucket}") String logBucketName,
+      @Value("${logging.file.path}") String logFilePath,
+      @Value("${logging.file.name}") String logFileName
+  ) {
+    this.s3Client = s3Client;
+    this.logBucketName = logBucketName;
+    this.logFilePath = logFilePath;
+    this.logFileName = logFileName;
+  }
+
+  @Override
+  public void uploadLogFile(LocalDate logDate) {
+    String logFilePathStr = generateLogFilePath(logDate);
+    Path logFile = Paths.get(logFilePathStr);
+
+    if (!Files.exists(logFile)) {
+      log.warn("로그 파일이 존재하지 않습니다: {}", logFilePathStr);
+      return;
+    }
+
+    String s3Key = generateS3Key(logDate);
+
+    try {
+      byte[] logBytes = Files.readAllBytes(logFile);
+      byte[] compressedBytes = compressGzip(logBytes);
+
+      PutObjectRequest putRequest = PutObjectRequest.builder()
+          .bucket(logBucketName)
+          .key(s3Key)
+          .contentType("application/gzip")
+          .build();
+
+      s3Client.putObject(putRequest, RequestBody.fromBytes(compressedBytes));
+
+      log.info("S3에 로그 파일 업로드 성공: bucket={}, key={}, size={} bytes", 
+          logBucketName, s3Key, compressedBytes.length);
+
+      Files.delete(logFile);
+      log.info("업로드 후 로컬 로그 파일 삭제 완료: {}", logFilePathStr);
+
+    } catch (IOException e) {
+      log.error("로그 파일 읽기 또는 압축 실패: {}", logFilePathStr, e);
+      throw new S3ServiceException("로그 파일 업로드 처리 실패", e);
+    } catch (S3Exception e) {
+      log.error("로그 업로드 중 S3 오류 발생: bucket={}, key={}, statusCode={}", 
+          logBucketName, s3Key, e.statusCode(), e);
+      throw new S3ServiceException("로그 업로드 중 S3 서비스 오류", e);
+    }
+  }
+
+  @Override
+  public void cleanupLocalLogs(int daysToKeep) {
+    Path logDir = Paths.get(logFilePath);
+
+    if (!Files.exists(logDir) || !Files.isDirectory(logDir)) {
+      log.warn("로그 디렉토리가 존재하지 않습니다: {}", logFilePath);
+      return;
+    }
+
+    LocalDate cutoffDate = LocalDate.now().minusDays(daysToKeep);
+
+    try (Stream<Path> files = Files.list(logDir)) {
+      files.filter(path -> path.toString().endsWith(".log"))
+          .filter(path -> {
+            String fileName = path.getFileName().toString();
+            LocalDate fileDate = extractDateFromFileName(fileName);
+            return fileDate != null && fileDate.isBefore(cutoffDate);
+          })
+          .forEach(path -> {
+            try {
+              Files.delete(path);
+              log.info("오래된 로그 파일 삭제 완료: {}", path);
+            } catch (IOException e) {
+              log.error("오래된 로그 파일 삭제 실패: {}", path, e);
+            }
+          });
+    } catch (IOException e) {
+      log.error("로그 디렉토리 조회 실패: {}", logFilePath, e);
+    }
+  }
+
+  @Override
+  public boolean logFileExists(LocalDate logDate) {
+    String logFilePathStr = generateLogFilePath(logDate);
+    return Files.exists(Paths.get(logFilePathStr));
+  }
+
+  private String generateLogFilePath(LocalDate logDate) {
+    return logFilePath + "/" + logFileName + "." + logDate.format(DATE_FORMATTER) + ".log";
+  }
+
+  private String generateS3Key(LocalDate logDate) {
+    return KEY_PREFIX + logDate.format(DATE_FORMATTER) + FILE_EXTENSION;
+  }
+
+  private byte[] compressGzip(byte[] data) throws IOException {
+    ByteArrayOutputStream byteStream = new ByteArrayOutputStream(data.length);
+    try (GZIPOutputStream gzipStream = new GZIPOutputStream(byteStream)) {
+      gzipStream.write(data);
+    }
+    return byteStream.toByteArray();
+  }
+
+  private LocalDate extractDateFromFileName(String fileName) {
+    try {
+      String dateStr = fileName.replaceAll("^.*\\.", "").replaceAll("\\.log$", "");
+      return LocalDate.parse(dateStr, DATE_FORMATTER);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/monew/src/main/java/com/spring/monew/backup/service/impl/S3LogBackupServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/backup/service/impl/S3LogBackupServiceImpl.java
@@ -121,7 +121,7 @@ public class S3LogBackupServiceImpl implements LogBackupService {
   }
 
   private String generateLogFilePath(LocalDate logDate) {
-    return logFilePath + "/" + logFileName + "." + logDate.format(DATE_FORMATTER) + ".log";
+    return Paths.get(logFilePath, logFileName + "-" + logDate.format(DATE_FORMATTER) + ".log").toString();
   }
 
   private String generateS3Key(LocalDate logDate) {
@@ -138,7 +138,12 @@ public class S3LogBackupServiceImpl implements LogBackupService {
 
   private LocalDate extractDateFromFileName(String fileName) {
     try {
-      String dateStr = fileName.replaceAll("^.*\\.", "").replaceAll("\\.log$", "");
+      int dateStart = fileName.lastIndexOf('-');
+      int extensionIndex = fileName.lastIndexOf(".log");
+      if (dateStart < 0 || extensionIndex < 0 || dateStart >= extensionIndex) {
+        return null;
+      }
+      String dateStr = fileName.substring(dateStart + 1, extensionIndex);
       return LocalDate.parse(dateStr, DATE_FORMATTER);
     } catch (Exception e) {
       return null;

--- a/monew/src/main/java/com/spring/monew/backup/service/impl/S3LogBackupServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/backup/service/impl/S3LogBackupServiceImpl.java
@@ -125,7 +125,7 @@ public class S3LogBackupServiceImpl implements LogBackupService {
   }
 
   private String generateLogFilePath(LocalDate logDate) {
-    return Paths.get(logFilePath, logFileName + "-" + logDate.format(DATE_FORMATTER) + ".log").toString();
+    return Paths.get(logFilePath, logFileName + "." + logDate.format(DATE_FORMATTER) + ".log").toString();
   }
 
   private String generateS3Key(LocalDate logDate) {

--- a/monew/src/main/java/com/spring/monew/batch/config/ArticleBackupBatchConfig.java
+++ b/monew/src/main/java/com/spring/monew/batch/config/ArticleBackupBatchConfig.java
@@ -19,6 +19,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
@@ -54,12 +56,16 @@ public class ArticleBackupBatchConfig {
     @Bean
     @StepScope
     public JpaPagingItemReader<Article> articleBackupReader() {
-        Instant yesterday = Instant.now().minus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.DAYS);
-        Instant today = Instant.now().truncatedTo(ChronoUnit.DAYS);
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+        LocalDate yesterday = LocalDate.now(zoneId).minusDays(1);
+        LocalDate today = LocalDate.now(zoneId);
+
+        Instant startDate = yesterday.atStartOfDay(zoneId).toInstant();
+        Instant endDate = today.atStartOfDay(zoneId).toInstant();
 
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("startDate", yesterday);
-        parameters.put("endDate", today);
+        parameters.put("startDate", startDate);
+        parameters.put("endDate", endDate);
 
         return new JpaPagingItemReaderBuilder<Article>()
                 .name("articleBackupReader")

--- a/monew/src/main/java/com/spring/monew/batch/config/ArticleBackupBatchConfig.java
+++ b/monew/src/main/java/com/spring/monew/batch/config/ArticleBackupBatchConfig.java
@@ -1,0 +1,61 @@
+package com.spring.monew.batch.config;
+
+import com.spring.monew.article.domain.Article;
+import com.spring.monew.backup.dto.ArticleBackupDto;
+import com.spring.monew.batch.processor.ArticleBackupProcessor;
+import com.spring.monew.batch.writer.ArticleBackupWriter;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.Collections;
+
+@Configuration
+@RequiredArgsConstructor
+public class ArticleBackupBatchConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final EntityManagerFactory entityManagerFactory;
+    private final ArticleBackupProcessor articleBackupProcessor;
+    private final ArticleBackupWriter articleBackupWriter;
+
+    @Bean
+    public Job articleBackupJob() {
+        return new JobBuilder("articleBackupJob", jobRepository)
+                .start(articleBackupStep())
+                .build();
+    }
+
+    @Bean
+    public Step articleBackupStep() {
+        return new StepBuilder("articleBackupStep", jobRepository)
+                .<Article, ArticleBackupDto>chunk(100, transactionManager)
+                .reader(articleBackupReader())
+                .processor(articleBackupProcessor)
+                .writer(articleBackupWriter)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<Article> articleBackupReader() {
+        return new JpaPagingItemReaderBuilder<Article>()
+                .name("articleBackupReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT a FROM Article a WHERE a.isDeleted = false ORDER BY a.createdAt ASC")
+                .pageSize(100)
+                .parameterValues(Collections.emptyMap())
+                .build();
+    }
+}

--- a/monew/src/main/java/com/spring/monew/batch/config/ArticleBackupBatchConfig.java
+++ b/monew/src/main/java/com/spring/monew/batch/config/ArticleBackupBatchConfig.java
@@ -14,6 +14,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.database.JpaPagingItemReader;
 import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -21,7 +22,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,7 +46,7 @@ public class ArticleBackupBatchConfig {
     public Step articleBackupStep() {
         return new StepBuilder("articleBackupStep", jobRepository)
                 .<Article, ArticleBackupDto>chunk(100, transactionManager)
-                .reader(articleBackupReader())
+                .reader(articleBackupReader(null))
                 .processor(articleBackupProcessor)
                 .writer(articleBackupWriter)
                 .listener(articleBackupWriter)
@@ -55,13 +55,24 @@ public class ArticleBackupBatchConfig {
 
     @Bean
     @StepScope
-    public JpaPagingItemReader<Article> articleBackupReader() {
+    public JpaPagingItemReader<Article> articleBackupReader(
+            @Value("#{jobParameters['triggerType']}") String triggerType
+    ) {
         ZoneId zoneId = ZoneId.of("Asia/Seoul");
         LocalDate yesterday = LocalDate.now(zoneId).minusDays(1);
         LocalDate today = LocalDate.now(zoneId);
+        LocalDate tomorrow = LocalDate.now(zoneId).plusDays(1);
 
-        Instant startDate = yesterday.atStartOfDay(zoneId).toInstant();
-        Instant endDate = today.atStartOfDay(zoneId).toInstant();
+        Instant startDate;
+        Instant endDate;
+
+        if ("MANUAL".equals(triggerType)) {
+            startDate = yesterday.atStartOfDay(zoneId).toInstant();
+            endDate = tomorrow.atStartOfDay(zoneId).toInstant();
+        } else {
+            startDate = yesterday.atStartOfDay(zoneId).toInstant();
+            endDate = today.atStartOfDay(zoneId).toInstant();
+        }
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("startDate", startDate);

--- a/monew/src/main/java/com/spring/monew/batch/config/ArticleBackupBatchConfig.java
+++ b/monew/src/main/java/com/spring/monew/batch/config/ArticleBackupBatchConfig.java
@@ -18,7 +18,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
-import java.util.Collections;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 @RequiredArgsConstructor
@@ -44,18 +47,26 @@ public class ArticleBackupBatchConfig {
                 .reader(articleBackupReader())
                 .processor(articleBackupProcessor)
                 .writer(articleBackupWriter)
+                .listener(articleBackupWriter)
                 .build();
     }
 
     @Bean
     @StepScope
     public JpaPagingItemReader<Article> articleBackupReader() {
+        Instant yesterday = Instant.now().minus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.DAYS);
+        Instant today = Instant.now().truncatedTo(ChronoUnit.DAYS);
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("startDate", yesterday);
+        parameters.put("endDate", today);
+
         return new JpaPagingItemReaderBuilder<Article>()
                 .name("articleBackupReader")
                 .entityManagerFactory(entityManagerFactory)
-                .queryString("SELECT a FROM Article a WHERE a.isDeleted = false ORDER BY a.createdAt ASC")
+                .queryString("SELECT a FROM Article a WHERE a.isDeleted = false AND a.createdAt >= :startDate AND a.createdAt < :endDate ORDER BY a.createdAt ASC")
                 .pageSize(100)
-                .parameterValues(Collections.emptyMap())
+                .parameterValues(parameters)
                 .build();
     }
 }

--- a/monew/src/main/java/com/spring/monew/batch/config/ArticleBackupBatchConfig.java
+++ b/monew/src/main/java/com/spring/monew/batch/config/ArticleBackupBatchConfig.java
@@ -6,6 +6,7 @@ import com.spring.monew.batch.processor.ArticleBackupProcessor;
 import com.spring.monew.batch.writer.ArticleBackupWriter;
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -25,6 +26,7 @@ import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class ArticleBackupBatchConfig {
@@ -69,9 +71,13 @@ public class ArticleBackupBatchConfig {
         if ("MANUAL".equals(triggerType)) {
             startDate = yesterday.atStartOfDay(zoneId).toInstant();
             endDate = tomorrow.atStartOfDay(zoneId).toInstant();
+            log.info("수동 트리거: 백업 기간 설정 - startDate: {} ({}), endDate: {} ({})", 
+                    startDate, yesterday, endDate, tomorrow);
         } else {
             startDate = yesterday.atStartOfDay(zoneId).toInstant();
             endDate = today.atStartOfDay(zoneId).toInstant();
+            log.info("스케줄 트리거: 백업 기간 설정 - startDate: {} ({}), endDate: {} ({})", 
+                    startDate, yesterday, endDate, today);
         }
 
         Map<String, Object> parameters = new HashMap<>();

--- a/monew/src/main/java/com/spring/monew/batch/config/LogBackupBatchConfig.java
+++ b/monew/src/main/java/com/spring/monew/batch/config/LogBackupBatchConfig.java
@@ -1,0 +1,60 @@
+package com.spring.monew.batch.config;
+
+import com.spring.monew.backup.service.LogBackupService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class LogBackupBatchConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final LogBackupService logBackupService;
+
+    @Bean
+    public Job logBackupJob() {
+        return new JobBuilder("logBackupJob", jobRepository)
+                .start(logBackupStep())
+                .build();
+    }
+
+    @Bean
+    public Step logBackupStep() {
+        return new StepBuilder("logBackupStep", jobRepository)
+                .tasklet(logBackupTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Tasklet logBackupTasklet() {
+        return (contribution, chunkContext) -> {
+            LocalDate yesterday = LocalDate.now().minusDays(1);
+            
+            log.info("로그 백업 시작: {}", yesterday);
+            
+            try {
+                logBackupService.uploadLogFile(yesterday);
+                log.info("로그 백업 성공: {}", yesterday);
+            } catch (Exception e) {
+                log.error("로그 백업 실패: {}", yesterday, e);
+                throw e;
+            }
+            
+            return RepeatStatus.FINISHED;
+        };
+    }
+}

--- a/monew/src/main/java/com/spring/monew/batch/controller/BatchJobController.java
+++ b/monew/src/main/java/com/spring/monew/batch/controller/BatchJobController.java
@@ -35,6 +35,26 @@ public class BatchJobController {
     }
 
     @Operation(
+            summary = "기사 백업 배치 작업 수동 트리거",
+            description = "articleBackupJob을 수동으로 실행하여 모든 기사를 S3에 백업합니다."
+    )
+    @PostMapping("/trigger/article-backup")
+    public ResponseEntity<BatchJobTriggerResponse> triggerArticleBackupJob() {
+        BatchJobTriggerResponse response = batchJobService.triggerArticleBackupJob();
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "로그 백업 배치 작업 수동 트리거",
+            description = "logBackupJob을 수동으로 실행하여 로그 파일을 S3에 백업합니다."
+    )
+    @PostMapping("/trigger/log-backup")
+    public ResponseEntity<BatchJobTriggerResponse> triggerLogBackupJob() {
+        BatchJobTriggerResponse response = batchJobService.triggerLogBackupJob();
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
             summary = "배치 작업 실행 상세 조회",
             description = "특정 executionId의 배치 작업 실행 상세 정보를 조회합니다 (Step 통계 포함)."
     )

--- a/monew/src/main/java/com/spring/monew/batch/controller/BatchJobController.java
+++ b/monew/src/main/java/com/spring/monew/batch/controller/BatchJobController.java
@@ -2,6 +2,7 @@ package com.spring.monew.batch.controller;
 
 import com.spring.monew.batch.dto.response.BatchJobExecutionResponse;
 import com.spring.monew.batch.dto.response.BatchJobTriggerResponse;
+import com.spring.monew.batch.dto.response.CleanupTriggerResponse;
 import com.spring.monew.batch.service.BatchJobService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -42,7 +43,7 @@ public class BatchJobController {
 
     @Operation(
             summary = "기사 백업 배치 작업 수동 트리거",
-            description = "articleBackupJob을 수동으로 실행하여 모든 기사를 S3에 백업합니다."
+            description = "articleBackupJob을 수동으로 실행하여 어제+오늘 기사를 S3에 백업합니다."
     )
     @PostMapping("/trigger/article-backup")
     public ResponseEntity<BatchJobTriggerResponse> triggerArticleBackupJob() {
@@ -57,6 +58,20 @@ public class BatchJobController {
     @PostMapping("/trigger/log-backup")
     public ResponseEntity<BatchJobTriggerResponse> triggerLogBackupJob() {
         BatchJobTriggerResponse response = batchJobService.triggerLogBackupJob();
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "기사 정리 배치 작업 수동 트리거",
+            description = "논리 삭제된 지 30일이 지난 기사를 물리 삭제합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "배치 작업 성공"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @PostMapping("/trigger/article-cleanup")
+    public ResponseEntity<CleanupTriggerResponse> triggerArticleCleanupJob() {
+        CleanupTriggerResponse response = batchJobService.triggerArticleCleanupJob();
         return ResponseEntity.ok(response);
     }
 

--- a/monew/src/main/java/com/spring/monew/batch/dto/response/CleanupTriggerResponse.java
+++ b/monew/src/main/java/com/spring/monew/batch/dto/response/CleanupTriggerResponse.java
@@ -1,0 +1,34 @@
+package com.spring.monew.batch.dto.response;
+
+import java.time.Instant;
+
+public record CleanupTriggerResponse(
+    String jobName,
+    String status,
+    Instant triggerTime,
+    int successCount,
+    int failureCount,
+    String message
+) {
+    public static CleanupTriggerResponse success(String jobName, int successCount, int failureCount) {
+        return new CleanupTriggerResponse(
+            jobName,
+            "COMPLETED",
+            Instant.now(),
+            successCount,
+            failureCount,
+            "Cleanup job triggered successfully"
+        );
+    }
+
+    public static CleanupTriggerResponse failure(String jobName, String errorMessage) {
+        return new CleanupTriggerResponse(
+            jobName,
+            "FAILED",
+            Instant.now(),
+            0,
+            0,
+            errorMessage
+        );
+    }
+}

--- a/monew/src/main/java/com/spring/monew/batch/processor/ArticleBackupProcessor.java
+++ b/monew/src/main/java/com/spring/monew/batch/processor/ArticleBackupProcessor.java
@@ -1,0 +1,28 @@
+package com.spring.monew.batch.processor;
+
+import com.spring.monew.article.domain.Article;
+import com.spring.monew.backup.dto.ArticleBackupDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class ArticleBackupProcessor implements ItemProcessor<Article, ArticleBackupDto> {
+
+    @Override
+    public ArticleBackupDto process(Article article) throws Exception {
+        try {
+            ArticleBackupDto backupDto = ArticleBackupDto.from(article);
+            log.debug("기사 {} 백업 준비 완료", article.getId());
+            return backupDto;
+        } catch (Exception e) {
+            log.error("기사 {} 처리 실패: {}", article.getId(), e.getMessage(), e);
+            throw e;
+        }
+    }
+}

--- a/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleBackupScheduler.java
+++ b/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleBackupScheduler.java
@@ -1,0 +1,38 @@
+package com.spring.monew.batch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ArticleBackupScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job articleBackupJob;
+
+    @Scheduled(cron = "0 0 2 * * *")
+    public void runArticleBackup() {
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addDate("startTime", new Date())
+                    .addString("triggerType", "SCHEDULED")
+                    .addLong("triggerTime", System.currentTimeMillis())
+                    .toJobParameters();
+
+            log.info("기사 백업 배치 작업 시작");
+            jobLauncher.run(articleBackupJob, params);
+            log.info("기사 백업 배치 작업 완료");
+        } catch (Exception e) {
+            log.error("기사 백업 배치 작업 실행 실패", e);
+        }
+    }
+}

--- a/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleCleanupScheduler.java
+++ b/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleCleanupScheduler.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -17,39 +18,49 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ArticleCleanupScheduler {
 
+  private static final UUID SYSTEM_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+  private static final String REQUEST_ID_KEY = "requestId";
+
   private final ArticleRepository articleRepository;
   private final ArticleService articleService;
 
   @Scheduled(cron = "0 0 15 * * *")
   public void deleteSoftDeletedArticles() {
-    Instant startTime = Instant.now();
-    log.info("[Batch] 삭제된 게시글 정리 작업 시작");
+    String batchRequestId = "BATCH-CLEANUP-" + UUID.randomUUID();
+    MDC.put(REQUEST_ID_KEY, batchRequestId);
 
-    Instant threshold = Instant.now().minus(30, ChronoUnit.DAYS);
-    List<UUID> articleIds = articleRepository.findSoftDeletedBefore(threshold);
+    try {
+      Instant startTime = Instant.now();
+      log.info("[Batch] 삭제된 게시글 정리 작업 시작");
 
-    if (articleIds.isEmpty()) {
-      log.info("[Batch] 정리할 삭제된 게시글이 없습니다.");
-      return;
-    }
+      Instant threshold = Instant.now().minus(30, ChronoUnit.DAYS);
+      List<UUID> articleIds = articleRepository.findSoftDeletedBefore(threshold);
 
-    log.info("[Batch] 정리 대상 게시글 {}개 발견", articleIds.size());
-
-    int successCount = 0;
-    int failureCount = 0;
-
-    for (UUID articleId : articleIds) {
-      try {
-        articleService.hardDeleteArticle(articleId, null);
-        successCount++;
-      } catch (Exception e) {
-        failureCount++;
-        log.error("[Batch] 게시글 {} 정리 실패: {}", articleId, e.getMessage(), e);
+      if (articleIds.isEmpty()) {
+        log.info("[Batch] 정리할 삭제된 게시글이 없습니다.");
+        return;
       }
-    }
 
-    Duration executionTime = Duration.between(startTime, Instant.now());
-    log.info("[Batch] 삭제된 게시글 정리 작업 완료 - 성공: {}개, 실패: {}개, 실행 시간: {}초", 
-        successCount, failureCount, executionTime.getSeconds());
+      log.info("[Batch] 정리 대상 게시글 {}개 발견", articleIds.size());
+
+      int successCount = 0;
+      int failureCount = 0;
+
+      for (UUID articleId : articleIds) {
+        try {
+          articleService.hardDeleteArticle(articleId, SYSTEM_USER_ID);
+          successCount++;
+        } catch (Exception e) {
+          failureCount++;
+          log.error("[Batch] 게시글 {} 정리 실패: {}", articleId, e.getMessage(), e);
+        }
+      }
+
+      Duration executionTime = Duration.between(startTime, Instant.now());
+      log.info("[Batch] 삭제된 게시글 정리 작업 완료 - 성공: {}개, 실패: {}개, 실행 시간: {}초", 
+          successCount, failureCount, executionTime.getSeconds());
+    } finally {
+      MDC.remove(REQUEST_ID_KEY);
+    }
   }
 }

--- a/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleCleanupScheduler.java
+++ b/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleCleanupScheduler.java
@@ -63,4 +63,43 @@ public class ArticleCleanupScheduler {
       MDC.remove(REQUEST_ID_KEY);
     }
   }
+
+  public void deleteSoftDeletedArticlesManual() {
+    String batchRequestId = "MANUAL-CLEANUP-" + UUID.randomUUID();
+    MDC.put(REQUEST_ID_KEY, batchRequestId);
+
+    try {
+      Instant startTime = Instant.now();
+      log.info("[Manual] 삭제된 게시글 정리 작업 시작 (최근 30일)");
+
+      Instant thirtyDaysAgo = Instant.now().minus(30, ChronoUnit.DAYS);
+      List<UUID> articleIds = articleRepository.findSoftDeletedBetween(thirtyDaysAgo, Instant.now());
+
+      if (articleIds.isEmpty()) {
+        log.info("[Manual] 정리할 삭제된 게시글이 없습니다.");
+        return;
+      }
+
+      log.info("[Manual] 정리 대상 게시글 {}개 발견", articleIds.size());
+
+      int successCount = 0;
+      int failureCount = 0;
+
+      for (UUID articleId : articleIds) {
+        try {
+          articleService.hardDeleteArticle(articleId, SYSTEM_USER_ID);
+          successCount++;
+        } catch (Exception e) {
+          failureCount++;
+          log.error("[Manual] 게시글 {} 정리 실패: {}", articleId, e.getMessage(), e);
+        }
+      }
+
+      Duration executionTime = Duration.between(startTime, Instant.now());
+      log.info("[Manual] 삭제된 게시글 정리 작업 완료 - 성공: {}개, 실패: {}개, 실행 시간: {}초", 
+          successCount, failureCount, executionTime.getSeconds());
+    } finally {
+      MDC.remove(REQUEST_ID_KEY);
+    }
+  }
 }

--- a/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleCleanupScheduler.java
+++ b/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleCleanupScheduler.java
@@ -1,9 +1,7 @@
 package com.spring.monew.batch.scheduler;
 
 import com.spring.monew.article.repository.ArticleRepository;
-import com.spring.monew.articleview.repository.ArticleViewRepository;
-import com.spring.monew.comment.repository.CommentRepository;
-import jakarta.transaction.Transactional;
+import com.spring.monew.article.service.ArticleService;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -20,11 +18,9 @@ import org.springframework.stereotype.Component;
 public class ArticleCleanupScheduler {
 
   private final ArticleRepository articleRepository;
-  private final CommentRepository commentRepository;
-  private final ArticleViewRepository articleViewRepository;
+  private final ArticleService articleService;
 
   @Scheduled(cron = "0 0 15 * * *")
-  @Transactional
   public void deleteSoftDeletedArticles() {
     Instant startTime = Instant.now();
     log.info("[Batch] 삭제된 게시글 정리 작업 시작");
@@ -44,18 +40,7 @@ public class ArticleCleanupScheduler {
 
     for (UUID articleId : articleIds) {
       try {
-        commentRepository.deleteCommentLikesByArticleId(articleId);
-        log.debug("[Batch] 게시글 {} - 댓글 좋아요 삭제 완료", articleId);
-
-        commentRepository.deleteByArticleId(articleId);
-        log.debug("[Batch] 게시글 {} - 댓글 삭제 완료", articleId);
-
-        articleViewRepository.deleteByArticleId(articleId);
-        log.debug("[Batch] 게시글 {} - 조회 기록 삭제 완료", articleId);
-
-        articleRepository.hardDelete(articleId);
-        log.debug("[Batch] 게시글 {} - 게시글 삭제 완료", articleId);
-
+        articleService.hardDeleteArticle(articleId, null);
         successCount++;
       } catch (Exception e) {
         failureCount++;

--- a/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleCleanupScheduler.java
+++ b/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleCleanupScheduler.java
@@ -1,0 +1,70 @@
+package com.spring.monew.batch.scheduler;
+
+import com.spring.monew.article.repository.ArticleRepository;
+import com.spring.monew.articleview.repository.ArticleViewRepository;
+import com.spring.monew.comment.repository.CommentRepository;
+import jakarta.transaction.Transactional;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ArticleCleanupScheduler {
+
+  private final ArticleRepository articleRepository;
+  private final CommentRepository commentRepository;
+  private final ArticleViewRepository articleViewRepository;
+
+  @Scheduled(cron = "0 0 15 * * *")
+  @Transactional
+  public void deleteSoftDeletedArticles() {
+    Instant startTime = Instant.now();
+    log.info("[Batch] 삭제된 게시글 정리 작업 시작");
+
+    Instant threshold = Instant.now().minus(30, ChronoUnit.DAYS);
+    List<UUID> articleIds = articleRepository.findSoftDeletedBefore(threshold);
+
+    if (articleIds.isEmpty()) {
+      log.info("[Batch] 정리할 삭제된 게시글이 없습니다.");
+      return;
+    }
+
+    log.info("[Batch] 정리 대상 게시글 {}개 발견", articleIds.size());
+
+    int successCount = 0;
+    int failureCount = 0;
+
+    for (UUID articleId : articleIds) {
+      try {
+        commentRepository.deleteCommentLikesByArticleId(articleId);
+        log.debug("[Batch] 게시글 {} - 댓글 좋아요 삭제 완료", articleId);
+
+        commentRepository.deleteByArticleId(articleId);
+        log.debug("[Batch] 게시글 {} - 댓글 삭제 완료", articleId);
+
+        articleViewRepository.deleteByArticleId(articleId);
+        log.debug("[Batch] 게시글 {} - 조회 기록 삭제 완료", articleId);
+
+        articleRepository.hardDelete(articleId);
+        log.debug("[Batch] 게시글 {} - 게시글 삭제 완료", articleId);
+
+        successCount++;
+      } catch (Exception e) {
+        failureCount++;
+        log.error("[Batch] 게시글 {} 정리 실패: {}", articleId, e.getMessage(), e);
+      }
+    }
+
+    Duration executionTime = Duration.between(startTime, Instant.now());
+    log.info("[Batch] 삭제된 게시글 정리 작업 완료 - 성공: {}개, 실패: {}개, 실행 시간: {}초", 
+        successCount, failureCount, executionTime.getSeconds());
+  }
+}

--- a/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleCleanupScheduler.java
+++ b/monew/src/main/java/com/spring/monew/batch/scheduler/ArticleCleanupScheduler.java
@@ -38,7 +38,6 @@ public class ArticleCleanupScheduler {
 
       if (articleIds.isEmpty()) {
         log.info("[Batch] 정리할 삭제된 게시글이 없습니다.");
-        return;
       }
 
       log.info("[Batch] 정리 대상 게시글 {}개 발견", articleIds.size());
@@ -64,7 +63,7 @@ public class ArticleCleanupScheduler {
     }
   }
 
-  public void deleteSoftDeletedArticlesManual() {
+  public int[] deleteSoftDeletedArticlesManual() {
     String batchRequestId = "MANUAL-CLEANUP-" + UUID.randomUUID();
     MDC.put(REQUEST_ID_KEY, batchRequestId);
 
@@ -77,7 +76,7 @@ public class ArticleCleanupScheduler {
 
       if (articleIds.isEmpty()) {
         log.info("[Manual] 정리할 삭제된 게시글이 없습니다.");
-        return;
+        return new int[]{0, 0};
       }
 
       log.info("[Manual] 정리 대상 게시글 {}개 발견", articleIds.size());
@@ -98,6 +97,7 @@ public class ArticleCleanupScheduler {
       Duration executionTime = Duration.between(startTime, Instant.now());
       log.info("[Manual] 삭제된 게시글 정리 작업 완료 - 성공: {}개, 실패: {}개, 실행 시간: {}초", 
           successCount, failureCount, executionTime.getSeconds());
+      return new int[]{successCount, failureCount};
     } finally {
       MDC.remove(REQUEST_ID_KEY);
     }

--- a/monew/src/main/java/com/spring/monew/batch/scheduler/LogBackupScheduler.java
+++ b/monew/src/main/java/com/spring/monew/batch/scheduler/LogBackupScheduler.java
@@ -1,0 +1,38 @@
+package com.spring.monew.batch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LogBackupScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job logBackupJob;
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void runLogBackup() {
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addDate("startTime", new Date())
+                    .addString("triggerType", "SCHEDULED")
+                    .addLong("triggerTime", System.currentTimeMillis())
+                    .toJobParameters();
+
+            log.info("로그 백업 배치 작업 시작");
+            jobLauncher.run(logBackupJob, params);
+            log.info("로그 백업 배치 작업 완료");
+        } catch (Exception e) {
+            log.error("로그 백업 배치 작업 실행 실패", e);
+        }
+    }
+}

--- a/monew/src/main/java/com/spring/monew/batch/service/BatchJobService.java
+++ b/monew/src/main/java/com/spring/monew/batch/service/BatchJobService.java
@@ -2,7 +2,9 @@ package com.spring.monew.batch.service;
 
 import com.spring.monew.batch.dto.response.BatchJobExecutionResponse;
 import com.spring.monew.batch.dto.response.BatchJobTriggerResponse;
+import com.spring.monew.batch.dto.response.CleanupTriggerResponse;
 import com.spring.monew.batch.exception.BatchJobExecutionNotFoundException;
+import com.spring.monew.batch.scheduler.ArticleCleanupScheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
@@ -28,6 +30,7 @@ public class BatchJobService {
     private final Job logBackupJob;
     private final JobRepository jobRepository;
     private final JobExplorer jobExplorer;
+    private final ArticleCleanupScheduler articleCleanupScheduler;
 
     public BatchJobTriggerResponse triggerNewsCollectionJob() {
         log.info("newsCollectionJob 수동 실행 요청");
@@ -83,6 +86,19 @@ public class BatchJobService {
         } catch (Exception e) {
             log.error("logBackupJob 실행 실패", e);
             throw new RuntimeException("배치 작업 실행 실패", e);
+        }
+    }
+
+    public CleanupTriggerResponse triggerArticleCleanupJob() {
+        log.info("articleCleanupJob 수동 실행 요청");
+
+        try {
+            articleCleanupScheduler.deleteSoftDeletedArticles();
+            log.info("articleCleanupJob 실행 완료");
+            return CleanupTriggerResponse.success("articleCleanupJob", 0, 0);
+        } catch (Exception e) {
+            log.error("articleCleanupJob 실행 실패", e);
+            return CleanupTriggerResponse.failure("articleCleanupJob", e.getMessage());
         }
     }
 

--- a/monew/src/main/java/com/spring/monew/batch/service/BatchJobService.java
+++ b/monew/src/main/java/com/spring/monew/batch/service/BatchJobService.java
@@ -93,7 +93,7 @@ public class BatchJobService {
         log.info("articleCleanupJob 수동 실행 요청");
 
         try {
-            articleCleanupScheduler.deleteSoftDeletedArticles();
+            articleCleanupScheduler.deleteSoftDeletedArticlesManual();
             log.info("articleCleanupJob 실행 완료");
             return CleanupTriggerResponse.success("articleCleanupJob", 0, 0);
         } catch (Exception e) {

--- a/monew/src/main/java/com/spring/monew/batch/service/BatchJobService.java
+++ b/monew/src/main/java/com/spring/monew/batch/service/BatchJobService.java
@@ -24,6 +24,8 @@ public class BatchJobService {
 
     private final JobLauncher jobLauncher;
     private final Job newsCollectionJob;
+    private final Job articleBackupJob;
+    private final Job logBackupJob;
     private final JobRepository jobRepository;
     private final JobExplorer jobExplorer;
 
@@ -42,6 +44,44 @@ public class BatchJobService {
             return BatchJobTriggerResponse.from(jobExecution);
         } catch (Exception e) {
             log.error("newsCollectionJob 실행 실패", e);
+            throw new RuntimeException("배치 작업 실행 실패", e);
+        }
+    }
+
+    public BatchJobTriggerResponse triggerArticleBackupJob() {
+        log.info("articleBackupJob 수동 실행 요청");
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("triggerType", "MANUAL")
+                .addLong("triggerTime", System.currentTimeMillis())
+                .toJobParameters();
+
+        try {
+            JobExecution jobExecution = jobLauncher.run(articleBackupJob, jobParameters);
+            log.info("articleBackupJob 실행 성공 - executionId: {}, status: {}",
+                    jobExecution.getId(), jobExecution.getStatus());
+            return BatchJobTriggerResponse.from(jobExecution);
+        } catch (Exception e) {
+            log.error("articleBackupJob 실행 실패", e);
+            throw new RuntimeException("배치 작업 실행 실패", e);
+        }
+    }
+
+    public BatchJobTriggerResponse triggerLogBackupJob() {
+        log.info("logBackupJob 수동 실행 요청");
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("triggerType", "MANUAL")
+                .addLong("triggerTime", System.currentTimeMillis())
+                .toJobParameters();
+
+        try {
+            JobExecution jobExecution = jobLauncher.run(logBackupJob, jobParameters);
+            log.info("logBackupJob 실행 성공 - executionId: {}, status: {}",
+                    jobExecution.getId(), jobExecution.getStatus());
+            return BatchJobTriggerResponse.from(jobExecution);
+        } catch (Exception e) {
+            log.error("logBackupJob 실행 실패", e);
             throw new RuntimeException("배치 작업 실행 실패", e);
         }
     }

--- a/monew/src/main/java/com/spring/monew/batch/service/BatchJobService.java
+++ b/monew/src/main/java/com/spring/monew/batch/service/BatchJobService.java
@@ -93,9 +93,9 @@ public class BatchJobService {
         log.info("articleCleanupJob 수동 실행 요청");
 
         try {
-            articleCleanupScheduler.deleteSoftDeletedArticlesManual();
+            int[] counts = articleCleanupScheduler.deleteSoftDeletedArticlesManual();
             log.info("articleCleanupJob 실행 완료");
-            return CleanupTriggerResponse.success("articleCleanupJob", 0, 0);
+            return CleanupTriggerResponse.success("articleCleanupJob", counts[0], counts[1]);
         } catch (Exception e) {
             log.error("articleCleanupJob 실행 실패", e);
             return CleanupTriggerResponse.failure("articleCleanupJob", e.getMessage());

--- a/monew/src/main/java/com/spring/monew/batch/writer/ArticleBackupWriter.java
+++ b/monew/src/main/java/com/spring/monew/batch/writer/ArticleBackupWriter.java
@@ -33,6 +33,7 @@ public class ArticleBackupWriter implements ItemWriter<ArticleBackupDto>, StepEx
             .toList();
 
         if (articles.isEmpty()) {
+            log.warn("청크가 비어있음 - 건너뜀");
             return;
         }
 
@@ -50,12 +51,18 @@ public class ArticleBackupWriter implements ItemWriter<ArticleBackupDto>, StepEx
 
     @Override
     public ExitStatus afterStep(StepExecution stepExecution) {
+        log.info("afterStep 호출됨 - aggregatedArticles 크기: {}", aggregatedArticles.size());
+        
         if (!aggregatedArticles.isEmpty()) {
             LocalDate backupDate = LocalDate.now().minusDays(1);
+            log.info("S3 업로드 시작: backupDate={}, 기사 수={}", backupDate, aggregatedArticles.size());
             s3BackupService.uploadBackup(backupDate, new ArrayList<>(aggregatedArticles));
             log.info("S3 백업 완료: {} 개의 기사", aggregatedArticles.size());
             aggregatedArticles.clear();
+        } else {
+            log.warn("백업할 기사가 없음 - S3 업로드 건너뜀");
         }
+        
         return ExitStatus.COMPLETED;
     }
 }

--- a/monew/src/main/java/com/spring/monew/batch/writer/ArticleBackupWriter.java
+++ b/monew/src/main/java/com/spring/monew/batch/writer/ArticleBackupWriter.java
@@ -13,6 +13,7 @@ import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,7 +55,7 @@ public class ArticleBackupWriter implements ItemWriter<ArticleBackupDto>, StepEx
         log.info("afterStep 호출됨 - aggregatedArticles 크기: {}", aggregatedArticles.size());
         
         if (!aggregatedArticles.isEmpty()) {
-            LocalDate backupDate = LocalDate.now().minusDays(1);
+            LocalDate backupDate = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
             log.info("S3 업로드 시작: backupDate={}, 기사 수={}", backupDate, aggregatedArticles.size());
             s3BackupService.uploadBackup(backupDate, new ArrayList<>(aggregatedArticles));
             log.info("S3 백업 완료: {} 개의 기사", aggregatedArticles.size());

--- a/monew/src/main/java/com/spring/monew/batch/writer/ArticleBackupWriter.java
+++ b/monew/src/main/java/com/spring/monew/batch/writer/ArticleBackupWriter.java
@@ -4,21 +4,26 @@ import com.spring.monew.backup.dto.ArticleBackupDto;
 import com.spring.monew.backup.service.S3BackupService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class ArticleBackupWriter implements ItemWriter<ArticleBackupDto> {
+public class ArticleBackupWriter implements ItemWriter<ArticleBackupDto>, StepExecutionListener {
 
     private final S3BackupService s3BackupService;
     private static final String BACKUP_COUNT_KEY = "backupCount";
+    private final List<ArticleBackupDto> aggregatedArticles = new ArrayList<>();
 
     @Override
     public void write(Chunk<? extends ArticleBackupDto> chunk) {
@@ -31,8 +36,7 @@ public class ArticleBackupWriter implements ItemWriter<ArticleBackupDto> {
             return;
         }
 
-        LocalDate backupDate = LocalDate.now();
-        s3BackupService.uploadBackup(backupDate, articles);
+        aggregatedArticles.addAll(articles);
 
         var ctx = StepSynchronizationManager.getContext();
         if (ctx != null && ctx.getStepExecution() != null) {
@@ -41,6 +45,17 @@ public class ArticleBackupWriter implements ItemWriter<ArticleBackupDto> {
             ec.put(BACKUP_COUNT_KEY, (currentCount != null ? currentCount : 0) + articles.size());
         }
 
-        log.info("청크 백업 완료: {} 개의 기사", articles.size());
+        log.info("청크 처리 완료: {} 개의 기사 (누적: {}개)", articles.size(), aggregatedArticles.size());
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        if (!aggregatedArticles.isEmpty()) {
+            LocalDate backupDate = LocalDate.now().minusDays(1);
+            s3BackupService.uploadBackup(backupDate, new ArrayList<>(aggregatedArticles));
+            log.info("S3 백업 완료: {} 개의 기사", aggregatedArticles.size());
+            aggregatedArticles.clear();
+        }
+        return ExitStatus.COMPLETED;
     }
 }

--- a/monew/src/main/java/com/spring/monew/batch/writer/ArticleBackupWriter.java
+++ b/monew/src/main/java/com/spring/monew/batch/writer/ArticleBackupWriter.java
@@ -1,0 +1,46 @@
+package com.spring.monew.batch.writer;
+
+import com.spring.monew.backup.dto.ArticleBackupDto;
+import com.spring.monew.backup.service.S3BackupService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ArticleBackupWriter implements ItemWriter<ArticleBackupDto> {
+
+    private final S3BackupService s3BackupService;
+    private static final String BACKUP_COUNT_KEY = "backupCount";
+
+    @Override
+    public void write(Chunk<? extends ArticleBackupDto> chunk) {
+        List<ArticleBackupDto> articles = chunk.getItems().stream()
+            .map(dto -> (ArticleBackupDto) dto)
+            .filter(dto -> dto != null)
+            .toList();
+
+        if (articles.isEmpty()) {
+            return;
+        }
+
+        LocalDate backupDate = LocalDate.now();
+        s3BackupService.uploadBackup(backupDate, articles);
+
+        var ctx = StepSynchronizationManager.getContext();
+        if (ctx != null && ctx.getStepExecution() != null) {
+            var ec = ctx.getStepExecution().getExecutionContext();
+            Integer currentCount = (Integer) ec.get(BACKUP_COUNT_KEY);
+            ec.put(BACKUP_COUNT_KEY, (currentCount != null ? currentCount : 0) + articles.size());
+        }
+
+        log.info("청크 백업 완료: {} 개의 기사", articles.size());
+    }
+}

--- a/monew/src/main/java/com/spring/monew/comment/repository/CommentRepository.java
+++ b/monew/src/main/java/com/spring/monew/comment/repository/CommentRepository.java
@@ -28,4 +28,15 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
 
   @Query(value = "SELECT * FROM comments c WHERE c.id = :commentId AND c.is_deleted = true", nativeQuery = true)
   Optional<Comment> findIncludingDeleted(@Param("commentId") UUID commentId);
+
+  @Modifying(clearAutomatically = true)
+  @Query(value = "DELETE FROM comment_likes WHERE comment_id IN (SELECT id FROM comments WHERE article_id = :articleId)", nativeQuery = true)
+  void deleteCommentLikesByArticleId(@Param("articleId") UUID articleId);
+
+  @Modifying(clearAutomatically = true)
+  @Query(value = "DELETE FROM comments WHERE article_id = :articleId", nativeQuery = true)
+  void deleteByArticleId(@Param("articleId") UUID articleId);
+
+  @Query(value = "SELECT COUNT(*) FROM comments WHERE article_id = :articleId", nativeQuery = true)
+  int countByArticleId(@Param("articleId") UUID articleId);
 }

--- a/monew/src/main/java/com/spring/monew/common/config/AwsS3Config.java
+++ b/monew/src/main/java/com/spring/monew/common/config/AwsS3Config.java
@@ -1,0 +1,37 @@
+package com.spring.monew.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsS3Config {
+
+  @Value("${aws.s3.region}")
+  private String region;
+
+  @Value("${aws.s3.access-key}")
+  private String accessKey;
+
+  @Value("${aws.s3.secret-key}")
+  private String secretKey;
+
+  @Bean
+  public S3Client s3Client() {
+    if (accessKey == null || accessKey.isEmpty() || secretKey == null || secretKey.isEmpty()) {
+      return S3Client.builder()
+          .region(Region.of(region))
+          .build();
+    }
+
+    AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+    return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+        .build();
+  }
+}

--- a/monew/src/main/java/com/spring/monew/common/config/AwsS3Config.java
+++ b/monew/src/main/java/com/spring/monew/common/config/AwsS3Config.java
@@ -20,7 +20,7 @@ public class AwsS3Config {
   @Value("${aws.s3.secret-key}")
   private String secretKey;
 
-  @Bean
+  @Bean(destroyMethod = "close")
   public S3Client s3Client() {
     if (accessKey == null || accessKey.isEmpty() || secretKey == null || secretKey.isEmpty()) {
       return S3Client.builder()

--- a/monew/src/main/java/com/spring/monew/common/config/Test.java
+++ b/monew/src/main/java/com/spring/monew/common/config/Test.java
@@ -1,5 +1,0 @@
-package com.spring.monew.common.config;
-
-public class Test {
-
-}

--- a/monew/src/main/java/com/spring/monew/common/exception/GlobalExceptionHandler.java
+++ b/monew/src/main/java/com/spring/monew/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.spring.monew.common.exception;
 
 import com.spring.monew.article.exception.ArticleNotFoundException;
+import com.spring.monew.backup.exception.BackupNotFoundException;
+import com.spring.monew.backup.exception.S3ServiceException;
 import jakarta.validation.ConstraintViolationException;
 import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
@@ -74,6 +76,31 @@ public class GlobalExceptionHandler {
         log.warn("리소스를 찾을 수 없음: {}", ex.getMessage());
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
         problemDetail.setTitle("리소스 없음");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(BackupNotFoundException.class)
+    public ProblemDetail handleBackupNotFoundException(BackupNotFoundException ex) {
+        log.warn("백업을 찾을 수 없음: {}", ex.getMessage());
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.NOT_FOUND,
+                ex.getMessage()
+        );
+        problemDetail.setTitle("백업 정보 없음");
+        problemDetail.setProperty("timestamp", Instant.now());
+        problemDetail.setProperty("backupDate", ex.getBackupDate());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(S3ServiceException.class)
+    public ProblemDetail handleS3ServiceException(S3ServiceException ex) {
+        log.error("S3 서비스 오류: {}", ex.getMessage());
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.SERVICE_UNAVAILABLE,
+                ex.getMessage()
+        );
+        problemDetail.setTitle("백업 서비스 일시 불가");
         problemDetail.setProperty("timestamp", Instant.now());
         return problemDetail;
     }

--- a/monew/src/main/java/com/spring/monew/common/filter/RequestIdFilter.java
+++ b/monew/src/main/java/com/spring/monew/common/filter/RequestIdFilter.java
@@ -18,7 +18,9 @@ public class RequestIdFilter extends OncePerRequestFilter {
 
     private static final String REQUEST_ID_HEADER = "X-Request-ID";
     private static final String REQUEST_ID_MDC_KEY = "requestId";
+    private static final String CLIENT_IP_MDC_KEY = "clientIp";
     private static final String REQUEST_ID_PREFIX = "req_";
+    private static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
 
     @Override
     protected void doFilterInternal(
@@ -27,18 +29,29 @@ public class RequestIdFilter extends OncePerRequestFilter {
         FilterChain filterChain
     ) throws ServletException, IOException {
         String requestId = generateRequestId();
+        String clientIp = extractClientIp(request);
         
         MDC.put(REQUEST_ID_MDC_KEY, requestId);
+        MDC.put(CLIENT_IP_MDC_KEY, clientIp);
         response.setHeader(REQUEST_ID_HEADER, requestId);
         
         try {
             filterChain.doFilter(request, response);
         } finally {
-            MDC.clear();
+            MDC.remove(REQUEST_ID_MDC_KEY);
+            MDC.remove(CLIENT_IP_MDC_KEY);
         }
     }
 
     private String generateRequestId() {
         return REQUEST_ID_PREFIX + UUID.randomUUID().toString();
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader(X_FORWARDED_FOR_HEADER);
+        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 }

--- a/monew/src/main/java/com/spring/monew/common/filter/RequestIdFilter.java
+++ b/monew/src/main/java/com/spring/monew/common/filter/RequestIdFilter.java
@@ -1,0 +1,44 @@
+package com.spring.monew.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    private static final String REQUEST_ID_HEADER = "X-Request-ID";
+    private static final String REQUEST_ID_MDC_KEY = "requestId";
+    private static final String REQUEST_ID_PREFIX = "req_";
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String requestId = generateRequestId();
+        
+        MDC.put(REQUEST_ID_MDC_KEY, requestId);
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    private String generateRequestId() {
+        return REQUEST_ID_PREFIX + UUID.randomUUID().toString();
+    }
+}

--- a/monew/src/main/java/com/spring/monew/common/logging/AuditLogger.java
+++ b/monew/src/main/java/com/spring/monew/common/logging/AuditLogger.java
@@ -1,0 +1,51 @@
+package com.spring.monew.common.logging;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class AuditLogger {
+
+    public void logSoftDelete(UUID articleId, UUID userId, String requestId) {
+        log.info("AUDIT [SOFT_DELETE] articleId={} userId={} requestId={} status=SUCCESS",
+                articleId, userId, requestId);
+    }
+
+    public void logSoftDeleteFailure(UUID articleId, UUID userId, String requestId, String reason) {
+        log.warn("AUDIT [SOFT_DELETE] articleId={} userId={} requestId={} status=FAILURE reason={}",
+                articleId, userId, requestId, reason);
+    }
+
+    public void logHardDelete(UUID articleId, UUID userId, String requestId, int commentsDeleted, int viewsDeleted) {
+        log.info("AUDIT [HARD_DELETE] articleId={} userId={} requestId={} commentsDeleted={} viewsDeleted={} status=SUCCESS",
+                articleId, userId, requestId, commentsDeleted, viewsDeleted);
+    }
+
+    public void logHardDeleteFailure(UUID articleId, UUID userId, String requestId, String reason) {
+        log.warn("AUDIT [HARD_DELETE] articleId={} userId={} requestId={} status=FAILURE reason={}",
+                articleId, userId, requestId, reason);
+    }
+
+    public void logRestore(Instant fromDate, Instant toDate, int restoredCount, UUID userId, String requestId) {
+        log.info("AUDIT [RESTORE] fromDate={} toDate={} restoredCount={} userId={} requestId={} status=SUCCESS",
+                fromDate, toDate, restoredCount, userId, requestId);
+    }
+
+    public void logRestoreFailure(Instant fromDate, Instant toDate, UUID userId, String requestId, String reason) {
+        log.warn("AUDIT [RESTORE] fromDate={} toDate={} userId={} requestId={} status=FAILURE reason={}",
+                fromDate, toDate, userId, requestId, reason);
+    }
+
+    public void logBackupCreation(UUID articleId, String backupKey, String requestId) {
+        log.info("AUDIT [BACKUP_CREATE] articleId={} backupKey={} requestId={} status=SUCCESS",
+                articleId, backupKey, requestId);
+    }
+
+    public void logBackupCreationFailure(UUID articleId, String requestId, String reason) {
+        log.warn("AUDIT [BACKUP_CREATE] articleId={} requestId={} status=FAILURE reason={}",
+                articleId, requestId, reason);
+    }
+}

--- a/monew/src/main/java/com/spring/monew/interest/domain/Interest.java
+++ b/monew/src/main/java/com/spring/monew/interest/domain/Interest.java
@@ -16,16 +16,21 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.jetbrains.annotations.TestOnly;
 
 @Entity
 @Table(name = "interests")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@SQLDelete(sql = "UPDATE interests SET is_deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLRestriction("is_deleted = false")
 public class Interest {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)   //PK 자동 삽입
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @Column(nullable = false, unique = true)
@@ -35,7 +40,6 @@ public class Interest {
     @Column(nullable = false, columnDefinition = "TEXT")
     private List<String> keywords;
 
-    /** DB TEXT(JSON) 직접 검색용: QueryDSL에서만 사용 */
     @Column(name = "keywords", insertable = false, updatable = false)
     private String keywordsString;
 
@@ -43,15 +47,26 @@ public class Interest {
     @CreationTimestamp
     private Instant createdAt;
 
+    @Column(name = "updated_at", nullable = false)
+    @UpdateTimestamp
+    private Instant updatedAt;
+
     @Column(name = "subscriptions_count", nullable = false)
     @ColumnDefault("0")
     private long subscriptionsCount;
+
+    @Column(name = "is_deleted", nullable = false)
+    @ColumnDefault("false")
+    private boolean isDeleted = false;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
 
     public Interest(String name, List<String> keywords) {
         this.name = name;
         this.keywords = keywords;
         this.createdAt = Instant.now();
-        this.subscriptionsCount = 0L; // 기본값 설정
+        this.subscriptionsCount = 0L;
     }
 
     public void update(List<String> keywords) {
@@ -68,7 +83,6 @@ public class Interest {
         }
     }
 
-    // 테스트 용
     @TestOnly
     public Interest(UUID id, String name, List<String> keywords, String keywordsString,
         Instant createdAt, long subscriptionsCount) {

--- a/monew/src/main/java/com/spring/monew/interest/domain/Interest.java
+++ b/monew/src/main/java/com/spring/monew/interest/domain/Interest.java
@@ -83,6 +83,11 @@ public class Interest {
         }
     }
 
+    public void undelete() {
+        this.isDeleted = false;
+        this.deletedAt = null;
+    }
+
     @TestOnly
     public Interest(UUID id, String name, List<String> keywords, String keywordsString,
         Instant createdAt, long subscriptionsCount) {

--- a/monew/src/main/java/com/spring/monew/interest/repository/InterestRepository.java
+++ b/monew/src/main/java/com/spring/monew/interest/repository/InterestRepository.java
@@ -1,10 +1,20 @@
 package com.spring.monew.interest.repository;
 
 import com.spring.monew.interest.domain.Interest;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InterestRepository extends JpaRepository<Interest, UUID>, InterestRepositoryCustom {
 
   boolean existsByName(String name);
+
+  @Query(value = "SELECT * FROM interests WHERE id = :interestId", nativeQuery = true)
+  Optional<Interest> findIncludingDeleted(@Param("interestId") UUID interestId);
+
+  @Query(value = "SELECT * FROM interests WHERE is_deleted = true ORDER BY deleted_at DESC LIMIT 1", nativeQuery = true)
+  Optional<Interest> findFirstDeleted();
 }

--- a/monew/src/main/java/com/spring/monew/interest/service/impl/InterestServiceImpl.java
+++ b/monew/src/main/java/com/spring/monew/interest/service/impl/InterestServiceImpl.java
@@ -1,5 +1,7 @@
 package com.spring.monew.interest.service.impl;
 
+import com.spring.monew.article.domain.Article;
+import com.spring.monew.article.repository.ArticleRepository;
 import com.spring.monew.interest.controller.dto.request.InterestRegisterRequest;
 import com.spring.monew.interest.controller.dto.request.InterestUpdateRequest;
 import com.spring.monew.interest.controller.dto.response.CursorPageResponseInterestDto;
@@ -12,22 +14,24 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class InterestServiceImpl implements InterestService {
 
   private final InterestRepository interestRepository;
+  private final ArticleRepository articleRepository;
 
   @Override
   @Transactional
   public InterestDto addInterest(InterestRegisterRequest registerRequest) {
     List<String> similarNames = interestRepository.findSimilarNames(registerRequest.name(), 0.45);
 
-    //예외 처리 필요 interests name exixsts
     if (interestRepository.existsByName(registerRequest.name())) {
       throw new IllegalArgumentException("같은 이름이 존재합니다.");
     }
@@ -84,6 +88,14 @@ public class InterestServiceImpl implements InterestService {
   public void removeInterest(UUID interestId) {
     Interest interest = interestRepository.findById(interestId)
         .orElseThrow(() -> new NoSuchElementException("존재하지 않는 관심사입니다."));
+
+    List<Article> relatedArticles = articleRepository.findAllByInterestId(interestId);
+    
+    if (!relatedArticles.isEmpty()) {
+      log.info("관심사 삭제로 인한 연관 게시글 소프트 삭제: interestId={}, articleCount={}", 
+          interestId, relatedArticles.size());
+      articleRepository.deleteAll(relatedArticles);
+    }
 
     interestRepository.delete(interest);
   }

--- a/monew/src/main/resources/application.yml
+++ b/monew/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none # 'none' for initial creation, 'validate' afterwards
+      ddl-auto: validate # 'none' for initial creation, 'validate' afterwards
     properties:
       hibernate:
         format_sql: true
@@ -24,7 +24,7 @@ spring:
 
   sql:
     init:
-      mode: always # 'always' for initial creation, 'never' afterwards
+      mode: never # 'always' for initial creation, 'never' afterwards
 
   data:
     mongodb:

--- a/monew/src/main/resources/application.yml
+++ b/monew/src/main/resources/application.yml
@@ -36,11 +36,11 @@ spring:
 
   batch:
     job:
+      enabled: false
+    trigger:
       enabled: true
     jdbc:
       initialize-schema: never
-    trigger:
-      enabled: true
 
   servlet:
     multipart:
@@ -60,6 +60,10 @@ logging:
     org.hibernate.type.descriptor.sql: WARN
     org.springframework.batch: INFO
     com.spring.monew: INFO
+  file:
+    path: ${LOG_FILE_PATH:./logs}
+    name: ${LOG_FILE_NAME:monew-application}
+    max-history: ${LOG_FILE_MAX_HISTORY:7}
 
 management:
   endpoints:
@@ -100,3 +104,11 @@ naver:
   api:
     client-id: ${NAVER_CLIENT_ID:dummy-naver-id}
     client-secret: ${NAVER_CLIENT_SECRET:dummy-naver-secret}
+
+aws:
+  s3:
+    region: ${AWS_REGION:ap-northeast-2}
+    bucket: ${AWS_S3_BUCKET:monew-article-backups}
+    log-bucket: ${AWS_S3_LOG_BUCKET:monew-bucket-s3-logback}
+    access-key: ${AWS_ACCESS_KEY_ID:}
+    secret-key: ${AWS_SECRET_ACCESS_KEY:}

--- a/monew/src/main/resources/application.yml
+++ b/monew/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate # 'none' for initial creation, 'validate' afterwards
+      ddl-auto: none # 'none' for initial creation, 'validate' afterwards
     properties:
       hibernate:
         format_sql: true
@@ -24,7 +24,7 @@ spring:
 
   sql:
     init:
-      mode: never # 'always' for initial creation, 'never' afterwards
+      mode: always # 'always' for initial creation, 'never' afterwards
 
   data:
     mongodb:

--- a/monew/src/main/resources/logback-spring.xml
+++ b/monew/src/main/resources/logback-spring.xml
@@ -32,6 +32,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <fileNamePattern>${LOG_FILE_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}.log</fileNamePattern>
       <maxHistory>7</maxHistory>
+      <totalSizeCap>3GB</totalSizeCap>
       <cleanHistoryOnStart>false</cleanHistoryOnStart>
     </rollingPolicy>
   </appender>

--- a/monew/src/main/resources/logback-spring.xml
+++ b/monew/src/main/resources/logback-spring.xml
@@ -9,6 +9,13 @@
   <property name="LOG_PATTERN_COLOR"
     value="%d{yy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%5level) %-36logger{36} [%X{requestId} | %X{requestMethod} | %X{requestUri}] - %msg%n"/>
 
+  <property name="LOG_PATTERN"
+    value="%d{yy-MM-dd HH:mm:ss.SSS} [%thread] %5level %-36logger{36} [%X{requestId} | %X{requestMethod} | %X{requestUri}] - %msg%n"/>
+
+  <!-- 로그 파일 경로 및 이름 -->
+  <springProperty scope="context" name="LOG_FILE_PATH" source="logging.file.path" defaultValue="./logs"/>
+  <springProperty scope="context" name="LOG_FILE_NAME" source="logging.file.name" defaultValue="monew-application"/>
+
   <!-- ✅ 콘솔 출력 (ECS → CloudWatch Logs로 전송됨) -->
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
@@ -16,9 +23,23 @@
     </encoder>
   </appender>
 
+  <!-- ✅ 파일 출력 (일별 롤링) -->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_FILE_PATH}/${LOG_FILE_NAME}.log</file>
+    <encoder>
+      <pattern>${LOG_PATTERN}</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_FILE_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>7</maxHistory>
+      <cleanHistoryOnStart>false</cleanHistoryOnStart>
+    </rollingPolicy>
+  </appender>
+
   <!-- ✅ 루트 로거 -->
   <root level="INFO">
     <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
   </root>
 
 </configuration>

--- a/monew/src/main/resources/schema-h2.sql
+++ b/monew/src/main/resources/schema-h2.sql
@@ -6,10 +6,10 @@ CREATE TABLE users (
                        email VARCHAR(255) NOT NULL UNIQUE,
                        nickname VARCHAR(20) NOT NULL,
                        password VARCHAR(255) NOT NULL,
-                       created_at TIMESTAMP NOT NULL,
+                       created_at TIMESTAMP WITH TIME ZONE NOT NULL,
                        role VARCHAR(20) NOT NULL,
                        is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
-                       deleted_at TIMESTAMP NULL
+                       deleted_at TIMESTAMP WITH TIME ZONE NULL
 );
 
 -- ==============================
@@ -18,10 +18,10 @@ CREATE TABLE users (
 CREATE TABLE interests (
                            id UUID PRIMARY KEY,
                            name VARCHAR(255) NOT NULL UNIQUE,
-                           created_at TIMESTAMP NOT NULL,
+                           created_at TIMESTAMP WITH TIME ZONE NOT NULL,
                            keywords TEXT NOT NULL,
                            subscriptions_count BIGINT NOT NULL DEFAULT 0,
-                           updated_at TIMESTAMP NOT NULL,
+                           updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
                            is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
                            deleted_at TIMESTAMP
 );
@@ -33,7 +33,7 @@ CREATE TABLE subscriptions (
                                id UUID PRIMARY KEY,
                                user_id UUID NOT NULL,
                                interest_id UUID NOT NULL,
-                               created_at TIMESTAMP NOT NULL,
+                               created_at TIMESTAMP WITH TIME ZONE NOT NULL,
                                CONSTRAINT fk_subscription_user FOREIGN KEY (user_id) REFERENCES users(id),
                                CONSTRAINT fk_subscription_interest FOREIGN KEY (interest_id) REFERENCES interests(id)
 );
@@ -47,14 +47,14 @@ CREATE TABLE articles (
                           source VARCHAR(20) NOT NULL,
                           source_url VARCHAR(255) NOT NULL UNIQUE,
                           title VARCHAR(255) NOT NULL,
-                          publish_date TIMESTAMP NOT NULL,
+                          publish_date TIMESTAMP WITH TIME ZONE NOT NULL,
                           summary TEXT NOT NULL,
                           comment_count BIGINT NOT NULL DEFAULT 0,
                           view_count BIGINT NOT NULL DEFAULT 0,
-                          created_at TIMESTAMP NOT NULL,
-                          updated_at TIMESTAMP NOT NULL,
+                          created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                          updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
                           is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
-                          deleted_at TIMESTAMP NULL,
+                          deleted_at TIMESTAMP WITH TIME ZONE NULL,
                           CONSTRAINT fk_article_interest FOREIGN KEY (interest_id) REFERENCES interests(id)
 );
 
@@ -65,7 +65,7 @@ CREATE TABLE article_views (
                                id UUID PRIMARY KEY,
                                article_id UUID NOT NULL,
                                user_id UUID NOT NULL,
-                               created_at TIMESTAMP NOT NULL,
+                               created_at TIMESTAMP WITH TIME ZONE NOT NULL,
                                CONSTRAINT fk_view_article FOREIGN KEY (article_id) REFERENCES articles(id),
                                CONSTRAINT fk_view_user FOREIGN KEY (user_id) REFERENCES users(id)
 );
@@ -78,9 +78,9 @@ CREATE TABLE comments (
                           article_id UUID NOT NULL,
                           user_id UUID NOT NULL,
                           content VARCHAR(255) NOT NULL,
-                          created_at TIMESTAMP NOT NULL,
+                          created_at TIMESTAMP WITH TIME ZONE NOT NULL,
                           is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
-                          deleted_at TIMESTAMP NULL,
+                          deleted_at TIMESTAMP WITH TIME ZONE NULL,
                           like_count BIGINT NOT NULL DEFAULT 0,
                           CONSTRAINT fk_comment_article FOREIGN KEY (article_id) REFERENCES articles(id),
                           CONSTRAINT fk_comment_user FOREIGN KEY (user_id) REFERENCES users(id)
@@ -93,7 +93,7 @@ CREATE TABLE comment_likes (
                                id UUID PRIMARY KEY,
                                comment_id UUID NOT NULL,
                                user_id UUID NOT NULL,
-                               created_at TIMESTAMP NOT NULL,
+                               created_at TIMESTAMP WITH TIME ZONE NOT NULL,
                                CONSTRAINT fk_like_comment FOREIGN KEY (comment_id) REFERENCES comments(id),
                                CONSTRAINT fk_like_user FOREIGN KEY (user_id) REFERENCES users(id)
 );
@@ -108,7 +108,7 @@ CREATE TABLE notifications (
                                confirmed BOOLEAN NOT NULL,
                                resource_type VARCHAR(20) NOT NULL,
                                resource_id UUID NOT NULL,
-                               created_at TIMESTAMP NOT NULL,
-                               updated_at TIMESTAMP NOT NULL,
+                               created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                               updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
                                CONSTRAINT fk_notification_user FOREIGN KEY (user_id) REFERENCES users(id)
 );

--- a/monew/src/main/resources/schema-h2.sql
+++ b/monew/src/main/resources/schema-h2.sql
@@ -20,7 +20,10 @@ CREATE TABLE interests (
                            name VARCHAR(255) NOT NULL UNIQUE,
                            created_at TIMESTAMP NOT NULL,
                            keywords TEXT NOT NULL,
-                           subscriptions_count BIGINT NOT NULL DEFAULT 0
+                           subscriptions_count BIGINT NOT NULL DEFAULT 0,
+                           updated_at TIMESTAMP NOT NULL,
+                           is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+                           deleted_at TIMESTAMP
 );
 
 -- ==============================

--- a/monew/src/main/resources/schema.sql
+++ b/monew/src/main/resources/schema.sql
@@ -276,7 +276,7 @@ ALTER TABLE batch_job_execution_context
 
 ALTER TABLE batch_step_execution_context
     ADD CONSTRAINT step_exec_ctx_fk FOREIGN KEY (step_execution_id) REFERENCES batch_step_execution(step_execution_id);
-    
+
 CREATE INDEX IF NOT EXISTS idx_notif_user_confirm_created_desc
     ON notifications (user_id, confirmed, created_at DESC, id DESC);
 

--- a/monew/src/main/resources/schema.sql
+++ b/monew/src/main/resources/schema.sql
@@ -64,7 +64,10 @@ CREATE TABLE interests
     name                VARCHAR(255) NOT NULL UNIQUE,
     created_at          TIMESTAMP WITH TIME ZONE  NOT NULL,
     keywords            TEXT         NOT NULL,
-    subscriptions_count BIGINT       NOT NULL DEFAULT 0
+    subscriptions_count BIGINT                NOT NULL DEFAULT 0,
+    updated_at          TIMESTAMP WITH TIME ZONE  NOT NULL,
+    is_deleted          BOOLEAN                   NOT NULL DEFAULT FALSE,
+    deleted_at          TIMESTAMP WITH TIME ZONE
 );
 
 -- name 컬럼 GIN 트라이그램 인덱스
@@ -107,7 +110,7 @@ CREATE TABLE articles
     deleted_at    TIMESTAMP WITH TIME ZONE      NULL,
     CONSTRAINT fk_article_interest FOREIGN KEY (interest_id)
         REFERENCES interests (id)
-        ON DELETE CASCADE ON UPDATE CASCADE
+        ON UPDATE CASCADE
 );
 
 -- ==============================

--- a/monew/src/test/java/com/spring/monew/interest/domain/InterestServiceTest.java
+++ b/monew/src/test/java/com/spring/monew/interest/domain/InterestServiceTest.java
@@ -9,6 +9,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 
+import com.spring.monew.article.domain.Article;
+import com.spring.monew.article.domain.ArticleSource;
+import com.spring.monew.article.repository.ArticleRepository;
 import com.spring.monew.interest.controller.dto.request.InterestRegisterRequest;
 import com.spring.monew.interest.controller.dto.request.InterestUpdateRequest;
 import com.spring.monew.interest.controller.dto.response.CursorPageResponseInterestDto;
@@ -35,6 +38,9 @@ class InterestServiceTest {
   @Mock
   private InterestRepository interestRepository;
 
+  @Mock
+  private ArticleRepository articleRepository;
+
   @InjectMocks
   private InterestServiceImpl interestService;
 
@@ -48,17 +54,14 @@ class InterestServiceTest {
   @Test
   @DisplayName("관심사 등록 성공")
   void addInterest_success() {
-    // given
     InterestRegisterRequest request = new InterestRegisterRequest("테스트", List.of("야구", "축구"));
 
     given(interestRepository.existsByName(anyString())).willReturn(false);
     given(interestRepository.findSimilarNames(anyString(), anyDouble())).willReturn(List.of());
     given(interestRepository.save(any(Interest.class))).willReturn(interest);
 
-    // when
     InterestDto result = interestService.addInterest(request);
 
-    // then
     assertThat(result.name()).isEqualTo("테스트");
     assertThat(result.keywords()).containsExactly("야구", "축구");
     verify(interestRepository).save(any(Interest.class));
@@ -67,11 +70,9 @@ class InterestServiceTest {
   @Test
   @DisplayName("같은 이름 존재 시 예외 발생")
   void addInterest_duplicateName_throwsException() {
-    // given
     InterestRegisterRequest request = new InterestRegisterRequest("테스트", List.of("야구", "축구"));
     given(interestRepository.existsByName("테스트")).willReturn(true);
 
-    // when & then
     assertThatThrownBy(() -> interestService.addInterest(request))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("같은 이름이 존재합니다.");
@@ -80,13 +81,11 @@ class InterestServiceTest {
   @Test
   @DisplayName("유사 이름 존재 시 예외 발생")
   void addInterest_similarName_throwsException() {
-    // given
     InterestRegisterRequest request = new InterestRegisterRequest("테스트", List.of("야구"));
     given(interestRepository.existsByName(anyString())).willReturn(false);
     given(interestRepository.findSimilarNames(anyString(), anyDouble()))
         .willReturn(List.of("테스투", "테스터"));
 
-    // when & then
     assertThatThrownBy(() -> interestService.addInterest(request))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("유사도가 높은 이름이 존재합니다.");
@@ -95,7 +94,6 @@ class InterestServiceTest {
   @Test
   @DisplayName("커서 기반 조회 성공")
   void getInterests_success() {
-    // given
     CursorPageResponseInterestDto response = new CursorPageResponseInterestDto(
         List.of(new InterestDto(UUID.randomUUID(), "테스트", List.of("야구"), 0L, false, Instant.now())),
         "cursorValue",
@@ -107,11 +105,9 @@ class InterestServiceTest {
     given(interestRepository.findCursorPagedInterests(
         any(), any(), any(), any(), any(), anyInt(), any())).willReturn(response);
 
-    // when
     CursorPageResponseInterestDto result = interestService.getInterests(
         "테스트", "name", "ASC", null, null, 10, UUID.randomUUID());
 
-    // then
     assertThat(result.content()).hasSize(1);
     assertThat(result.content().get(0).name()).isEqualTo("테스트");
   }
@@ -119,15 +115,12 @@ class InterestServiceTest {
   @Test
   @DisplayName("관심사 수정 성공")
   void modifyInterest_success() {
-    // given
     UUID interestId = UUID.randomUUID();
     InterestUpdateRequest updateRequest = new InterestUpdateRequest(List.of("테니스", "골프"));
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
 
-    // when
     InterestDto result = interestService.modifyInterest(interestId, updateRequest);
 
-    // then
     assertThat(result.name()).isEqualTo("테스트");
     assertThat(result.keywords()).containsExactly("테니스", "골프");
   }
@@ -135,11 +128,9 @@ class InterestServiceTest {
   @Test
   @DisplayName("존재하지 않으면 예외 발생")
   void modifyInterest_notFound_throwsException() {
-    // given
     UUID interestId = UUID.randomUUID();
     given(interestRepository.findById(interestId)).willReturn(Optional.empty());
 
-    // when & then
     assertThatThrownBy(() -> interestService.modifyInterest(interestId,
         new InterestUpdateRequest( List.of("테니스"))))
         .isInstanceOf(NoSuchElementException.class)
@@ -147,27 +138,44 @@ class InterestServiceTest {
   }
 
   @Test
-  @DisplayName("관심사 삭제 성공")
-  void removeInterest_success() {
-    // given
+  @DisplayName("관심사 삭제 성공 - 관련 게시글 없음")
+  void removeInterest_success_noArticles() {
     UUID interestId = UUID.randomUUID();
     given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(articleRepository.findAllByInterestId(interestId)).willReturn(List.of());
 
-    // when
     interestService.removeInterest(interestId);
 
-    // then
+    verify(articleRepository).findAllByInterestId(interestId);
+    verify(interestRepository).delete(interest);
+  }
+
+  @Test
+  @DisplayName("관심사 삭제 성공 - 관련 게시글도 소프트 삭제")
+  void removeInterest_success_withArticles() {
+    UUID interestId = UUID.randomUUID();
+    Article article1 = Article.of(interest, ArticleSource.NAVER, 
+        "https://example.com/1", "Article 1", Instant.now(), "Summary 1");
+    Article article2 = Article.of(interest, ArticleSource.NAVER, 
+        "https://example.com/2", "Article 2", Instant.now(), "Summary 2");
+    List<Article> relatedArticles = List.of(article1, article2);
+    
+    given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+    given(articleRepository.findAllByInterestId(interestId)).willReturn(relatedArticles);
+
+    interestService.removeInterest(interestId);
+
+    verify(articleRepository).findAllByInterestId(interestId);
+    verify(articleRepository).deleteAll(relatedArticles);
     verify(interestRepository).delete(interest);
   }
 
   @Test
   @DisplayName("존재하지 않으면 예외 발생")
   void removeInterest_notFound_throwsException() {
-    // given
     UUID interestId = UUID.randomUUID();
     given(interestRepository.findById(interestId)).willReturn(Optional.empty());
 
-    // when & then
     assertThatThrownBy(() -> interestService.removeInterest(interestId))
         .isInstanceOf(NoSuchElementException.class)
         .hasMessage("존재하지 않는 관심사입니다.");

--- a/monew/src/test/java/com/spring/monew/interest/service/InterestIntegrationTest.java
+++ b/monew/src/test/java/com/spring/monew/interest/service/InterestIntegrationTest.java
@@ -9,12 +9,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spring.monew.article.domain.Article;
+import com.spring.monew.article.domain.ArticleSource;
+import com.spring.monew.article.repository.ArticleRepository;
 import com.spring.monew.interest.controller.dto.request.InterestRegisterRequest;
 import com.spring.monew.interest.controller.dto.request.InterestUpdateRequest;
 import com.spring.monew.interest.domain.Interest;
 import com.spring.monew.interest.repository.InterestRepository;
 import com.spring.monew.user.domain.User;
 import com.spring.monew.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +51,8 @@ class InterestIntegrationTest {
 
   @Autowired private InterestRepository interestRepository;
   @Autowired private UserRepository userRepository;
+  @Autowired private ArticleRepository articleRepository;
+  @Autowired private EntityManager entityManager;
 
   private User user;
 
@@ -55,7 +62,7 @@ class InterestIntegrationTest {
           .withDatabaseName("monew_test")
           .withUsername("postgres")
           .withPassword("1234")
-          .withInitScript("schema.sql"); // 자동으로 CREATE EXTENSION 실행
+          .withInitScript("schema.sql");
 
   @DynamicPropertySource
   static void overrideProps(DynamicPropertyRegistry registry) {
@@ -119,14 +126,52 @@ class InterestIntegrationTest {
   }
 
   @Test
-  @DisplayName("관심사 삭제 성공")
+  @DisplayName("관심사 삭제 성공 - 관련 게시글도 소프트 삭제됨")
   void removeInterest() throws Exception {
     Interest saved = interestRepository.save(new Interest("삭제대상", List.of("tag")));
+    UUID interestId = saved.getId();
+    
+    Article article1 = Article.of(saved, ArticleSource.NAVER, 
+        "https://example.com/1", "제목1", Instant.now(), "요약1");
+    Article article2 = Article.of(saved, ArticleSource.NAVER, 
+        "https://example.com/2", "제목2", Instant.now(), "요약2");
+    
+    articleRepository.save(article1);
+    articleRepository.save(article2);
+    
+    UUID article1Id = article1.getId();
+    UUID article2Id = article2.getId();
+    
+    entityManager.flush();
+    entityManager.clear();
 
-    mockMvc.perform(delete("/api/interests/{interestId}", saved.getId()))
+    mockMvc.perform(delete("/api/interests/{interestId}", interestId))
         .andExpect(status().isOk());
 
-    assertThat(interestRepository.findById(saved.getId()).isEmpty()).isTrue();
+    entityManager.flush();
+    entityManager.clear();
+    
+    Boolean interestIsDeleted = (Boolean) entityManager.createNativeQuery(
+        "SELECT is_deleted FROM interests WHERE id = CAST(?1 AS uuid)")
+        .setParameter(1, interestId.toString())
+        .getSingleResult();
+    assertThat(interestIsDeleted).isTrue();
+    
+    Boolean article1IsDeleted = (Boolean) entityManager.createNativeQuery(
+        "SELECT is_deleted FROM articles WHERE id = CAST(?1 AS uuid)")
+        .setParameter(1, article1Id.toString())
+        .getSingleResult();
+    assertThat(article1IsDeleted).isTrue();
+    
+    Boolean article2IsDeleted = (Boolean) entityManager.createNativeQuery(
+        "SELECT is_deleted FROM articles WHERE id = CAST(?1 AS uuid)")
+        .setParameter(1, article2Id.toString())
+        .getSingleResult();
+    assertThat(article2IsDeleted).isTrue();
+    
+    assertThat(interestRepository.findById(interestId).isEmpty()).isTrue();
+    assertThat(articleRepository.findById(article1Id).isEmpty()).isTrue();
+    assertThat(articleRepository.findById(article2Id).isEmpty()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Issues
- closed #84

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

뉴스 기사 삭제 및 복구 기능을 구현. 소프트 삭제(논리적 삭제), 하드 삭제(물리적 삭제), AWS S3 백업, 복원 기능, 요청 추적 및 로그 관리 기능


#### 1️⃣ 소프트 삭제 (Soft Delete)
- **엔드포인트**: `DELETE /api/articles/{articleId}`
- **기능**: 기사를 논리적으로 삭제 (is_deleted = true, deleted_at 타임스탬프 기록)
- **특징**:
  - 실제 데이터는 DB에 보존되어 복구 가능
  - 삭제된 기사는 목록/검색에서 자동 제외 (@SQLRestriction 사용)
  - 연관된 댓글, 조회수 데이터는 유지
  - 멱등성 보장 (이미 삭제된 기사 재삭제 시 404 반환)

#### 2️⃣ 하드 삭제 (Hard Delete)
- **엔드포인트**: `DELETE /api/articles/{articleId}/hard`
- **기능**: 기사 및 연관 데이터를 DB에서 완전히 삭제
- **Cascade 삭제 대상**:
  - Comment (댓글)
  - CommentLike (댓글 좋아요)
  - ArticleView (조회수 기록)
- **특징**:
  - 트랜잭션으로 묶어 원자적 처리
  - 소프트 삭제된 기사도 하드 삭제 가능

#### 3️⃣ 기사 복원 (Restore)
- **엔드포인트**: `GET /api/articles/{articleId}/restore`
- **기능**: 물리적 삭제된 기사를 복원
- **동작**:
  - deletedAt 필드를 null로 초기화
  - 복원된 기사는 즉시 목록/검색에 노출

#### 4️⃣ S3 자동 백업 시스템
- **백업 배치 작업** (매일 새벽 2시 실행):
  - 전날 기사를 JSON 형식으로 S3에 백업, 중복없이 백업
  - 파일명 규칙: `deleted-articles-YYYY-MM-DD.json`
  - S3 버킷: `monew-article-backups`

- **로그 백업 배치 작업** (매일 새벽 1시 실행):
  - 애플리케이션 로그 파일을 GZIP 압축 후 S3에 업로드
  - 파일명 규칙: `monew-application-YYYY-MM-DD.log.gz`
  - S3 버킷: `monew-bucket-s3-logback`
  - 업로드 성공 시 로컬 로그 파일 자동 삭제

- **수동 백업 트리거 API**:
  - 기사 백업: `POST /api/batch/trigger/article-backup`
  - 로그 백업: `POST /api/batch/trigger/log-backup`

#### 5️⃣ 요청 추적 및 감사 로깅
- **Request ID 필터**:
  - 모든 HTTP 요청에 고유 Request ID 자동 부여
  - MDC(Mapped Diagnostic Context)에 Request ID, Client IP 기록
  - 응답 헤더에 `X-Request-ID` 포함

- **감사 로그 (AuditLogger)**:
  - 모든 삭제/복원 작업 로깅
  - 로그 항목: Request ID, 사용자 ID, 기사 ID, 작업 유형, 타임스탬프

- **Logback 파일 로깅**:
  - 일별 로그 파일 롤링 (`monew-application-YYYY-MM-DD.log`)
  - 최대 7일 보관, 총 크기 3GB 제한
## 📷 Screenshot

### 관심사 삭제 시 관련 기사 논리 삭제
<img width="1790" height="1000" alt="image" src="https://github.com/user-attachments/assets/c3ca589b-37db-4945-9cc9-9dd9356038f7" />

### 관심사도 논리 삭제 됩니다.
<img width="2338" height="898" alt="image" src="https://github.com/user-attachments/assets/316ca3de-7fa5-431b-9773-e28fd1f48076" />


### 로그 S3 백업 (로그 백업 수동 트리거 사용)
<img width="2328" height="1114" alt="image" src="https://github.com/user-attachments/assets/32b75650-c84b-47a0-9aeb-3f748b15b17d" />

<img width="2762" height="510" alt="image" src="https://github.com/user-attachments/assets/1e97fc08-ad08-4089-a87f-0fb1a738ccde" />

### S3에서 로그가 잘 저장 되었습니다. 
<img width="2716" height="1332" alt="image" src="https://github.com/user-attachments/assets/a649f2b4-c131-4cf3-8790-44b02dac933d" />


### 뉴스 기사 백업 (수동트리거를 통해 테스트함)
### 수동트리거는 어제부터 오늘까지 기사 백업함( 기존 배치 스케줄러는 어제 기사만)
1. 스케줄러 (매일 새벽 2시): triggerType=SCHEDULED → 전날 기사만 백업
2. 수동 트리거 (POST /api/batch/trigger/article-backup): triggerType=MANUAL → 어제 + 오늘 기사 백업

<img width="2298" height="1226" alt="image" src="https://github.com/user-attachments/assets/a4e9cc01-6ac2-4079-adde-bf73c64f6e00" />

### S3에서 뉴스 기사가 잘 백업 되었습니다.
<img width="2800" height="1364" alt="image" src="https://github.com/user-attachments/assets/090deea0-9a9b-44f5-a9ea-acb910163743" />


## 복구

### 복구를 하기 위해 논리삭제 자동 물리 삭제 트리거를 만들었습니다.
### 뉴스 기사 배치 자동 삭제 트리거 - 30일 전부터 오늘까지 ( 원래 30일 지나야 자동 삭제 됨)
### 논리적 삭제 기사들 자동 삭제
http://localhost:8080/api/batch/trigger/article-cleanup

### 기존 DB 논리삭제됨
<img width="1941" height="1000" alt="image" src="https://github.com/user-attachments/assets/175d46a0-d8ba-40d9-beb3-8bb6c6e414e7" />

### 삭제 트리거
<img width="2506" height="1186" alt="image" src="https://github.com/user-attachments/assets/e2c3abfc-8091-4684-997e-33242a362bb4" />

### DB에서 없어짐
<img width="1824" height="596" alt="image" src="https://github.com/user-attachments/assets/7902e420-c4d2-485c-b4b3-55b3d071e63b" />


### 기사 복구
<img width="2178" height="1422" alt="image" src="https://github.com/user-attachments/assets/70057ae7-7fed-483d-a796-a30ea3526349" />

<img width="1994" height="1212" alt="image" src="https://github.com/user-attachments/assets/98cea869-0cb5-4b8f-82ca-b1e2d327adca" />

### 복구 완료
<img width="2796" height="760" alt="image" src="https://github.com/user-attachments/assets/9ba15819-6d79-4347-a2a7-e36bb990beb1" />
<img width="2026" height="1408" alt="image" src="https://github.com/user-attachments/assets/b19b8010-370e-48e1-a590-e172f0c78816" />
<img width="2122" height="1204" alt="image" src="https://github.com/user-attachments/assets/75a4e043-f1f7-490d-bc27-60d5a79d8c59" />




## 📚 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 문서 소프트/하드 삭제 및 기간 지정 복구 API 추가
  * 일별 문서 백업·로그 백업 스케줄러 및 수동 트리거 추가
  * 요청별 고유 ID 응답 헤더와 감사 로그 기록 적용
  * 백업 복원 결과 반환 기능 추가
* **Chores**
  * AWS S3 기반 백업 저장소 연동 및 배치 백업 파이프라인 도입
  * 파일 기반 로그 롤링 설정 및 파일 로그 출력 추가
* **버그 수정**
  * S3/백업 예외 처리 및 전역 예외 응답 보강
  * 관심사(Interest) 소프트 삭제 및 관련 게시물 정리 동작 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->